### PR TITLE
Functions manipulating prefix/suffix

### DIFF
--- a/str.lisp
+++ b/str.lisp
@@ -33,6 +33,8 @@
    :prefixp
    :suffix?
    :suffixp
+   :add-prefix
+   :add-suffix
    :unlines
    :from-file
    :to-file
@@ -251,6 +253,14 @@ A simple call to the built-in `search` (which returns the position of the substr
   (when (string= s (suffix items)) s))
 
 (setf (fdefinition 'suffixp) #'suffix?)
+
+(defun add-prefix (items s)
+  "Prepend s to the front of each items."
+  (mapcar #'(lambda (item) (concat s item)) items))
+
+(defun add-suffix (items s)
+  "Append s to the end of eahc items."
+  (mapcar #'(lambda (item) (concat item s)) items))
 
 (defun from-file (pathname &rest keys)
   "Read the file and return its content as a string.

--- a/str.lisp
+++ b/str.lisp
@@ -27,7 +27,8 @@
    :starts-with-p
    :ends-with?
    :ends-with-p
-   :common-prefix
+   :prefix
+   :suffix
    :unlines
    :from-file
    :to-file
@@ -199,23 +200,41 @@ A simple call to the built-in `search` (which returns the position of the substr
 
 (setf (fdefinition 'containsp) #'contains?)
 
-(defun common-prefix-1 (item1 item2)
+(defun prefix-1 (item1 item2)
   (subseq item1 0 (or (mismatch item1 item2) (length item1))))
 
-(defun common-prefix (items)
+(defun prefix (items)
   "Find the common prefix between strings.
 
    Uses the built-in `mismatch', that returns the position at which
    the strings fail to match.
 
-   Example: `(str:common-prefix '(\"foobar\" \"foozz\"))` => \"foo\"
+   Example: `(str:prefix '(\"foobar\" \"foozz\"))` => \"foo\"
 
    - items: list of strings
    - Return: a string.
 
   "
   (when items
-    (reduce #'common-prefix-1 items)))
+    (reduce #'prefix-1 items)))
+
+(defun suffix-1 (item1 item2)
+  (subseq item1 (or (mismatch item1 item2 :from-end t) 0)))
+
+(defun suffix (items)
+  "Find the common suffix between strings.
+
+   Uses the built-in `mismatch', that returns the position at which
+   the strings fail to match.
+
+   Example: `(str:suffix '(\"foobar\" \"zzbar\"))` => \"bar\"
+
+   - items: list of strings
+   - Return: a string.
+
+  "
+  (when items
+    (reduce #'suffix-1 items)))
 
 (defun from-file (pathname &rest keys)
   "Read the file and return its content as a string.

--- a/str.lisp
+++ b/str.lisp
@@ -29,6 +29,10 @@
    :ends-with-p
    :prefix
    :suffix
+   :prefix?
+   :prefixp
+   :suffix?
+   :suffixp
    :unlines
    :from-file
    :to-file
@@ -235,6 +239,18 @@ A simple call to the built-in `search` (which returns the position of the substr
   "
   (when items
     (reduce #'suffix-1 items)))
+
+(defun prefix? (items s)
+  "Return s if s is common prefix between items."
+  (when (string= s (prefix items)) s))
+
+(setf (fdefinition 'prefixp) #'prefix?)
+
+(defun suffix? (items s)
+  "Return s if s is common suffix between items."
+  (when (string= s (suffix items)) s))
+
+(setf (fdefinition 'suffixp) #'suffix?)
 
 (defun from-file (pathname &rest keys)
   "Read the file and return its content as a string.

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -150,12 +150,26 @@
   (is (prefix '("foobar" nil)) "" "with a nil")
   (is (prefix '()) nil "with void list"))
 
+(subtest "prefix?"
+  (is (prefix? '("foobar" "footeam") "foo") "foo" "default case")
+  (is (prefix?'("foobar" "barfoo") "") "" "no common prefix")
+  (is (prefix? '("foobar" "") "") "" "with empty string")
+  (is (prefix? '("foobar" nil) "") "" "with a nil")
+  (is (prefix? '() nil) nil "with void list"))
+
 (subtest "suffix"
   (is (suffix '("foobar" "teambar")) "bar" "default case")
   (is (suffix '("foobar" "barfoo")) "" "no common suffix")
   (is (suffix '("foobar" "")) "" "with empty string")
   (is (suffix '("foobar" nil)) "" "with a nil")
   (is (suffix '()) nil "with void list"))
+
+(subtest "suffix?"
+  (is (suffix? '("foobar" "teambar") "bar") "bar" "default case")
+  (is (suffix?'("foobar" "barfoo") "") "" "no common suffix")
+  (is (suffix? '("foobar" "") "") "" "with empty string")
+  (is (suffix? '("foobar" nil) "") "" "with a nil")
+  (is (suffix? '() nil) nil "with void list"))
 
 (subtest "contains?"
   (ok (contains? "foo" "blafoobar") "default")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -171,6 +171,16 @@
   (is (suffix? '("foobar" nil) "") "" "with a nil")
   (is (suffix? '() nil) nil "with void list"))
 
+(subtest "add-prefix"
+  (is (add-prefix '("bar" "team") "foo") '("foobar" "footeam") "default case")
+  (is (add-prefix '("bar" nil) "foo") '("foobar" "foo") "with a nil")
+  (is (add-prefix '() "foo") '() "with void list"))
+
+(subtest "add-suffix"
+  (is (add-suffix '("foo" "team") "bar") '("foobar" "teambar") "default case")
+  (is (add-suffix '("foo" nil) "bar") '("foobar" "bar") "with a nil")
+  (is (add-suffix '() "foo") '() "with void list"))
+
 (subtest "contains?"
   (ok (contains? "foo" "blafoobar") "default")
   (ok (not (contains? "foo" "")) "with no string")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -143,12 +143,19 @@
   (ok (not (ends-with? "BAR" "foobar")) "don't ignore case")
   (ok (ends-with? "BAR" "foobar" :ignore-case t) "ignore case"))
 
-(subtest "common-prefix"
-  (is (common-prefix '("foobar" "footeam")) "foo" "default case")
-  (is (common-prefix '("foobar" "barfoo")) "" "no common prefix")
-  (is (common-prefix '("foobar" "")) "" "with empty string")
-  (is (common-prefix '("foobar" nil)) "" "with a nil")
-  (is (common-prefix '()) nil "with void list"))
+(subtest "prefix"
+  (is (prefix '("foobar" "footeam")) "foo" "default case")
+  (is (prefix '("foobar" "barfoo")) "" "no common prefix")
+  (is (prefix '("foobar" "")) "" "with empty string")
+  (is (prefix '("foobar" nil)) "" "with a nil")
+  (is (prefix '()) nil "with void list"))
+
+(subtest "suffix"
+  (is (suffix '("foobar" "teambar")) "bar" "default case")
+  (is (suffix '("foobar" "barfoo")) "" "no common suffix")
+  (is (suffix '("foobar" "")) "" "with empty string")
+  (is (suffix '("foobar" nil)) "" "with a nil")
+  (is (suffix '()) nil "with void list"))
 
 (subtest "contains?"
   (ok (contains? "foo" "blafoobar") "default")


### PR DESCRIPTION
Hello,
This PR proposes some additions/changes about manipulating prefix/suffix.

### changes
- Rename `common-prefix` -> `prefix`

### additions
- `suffix`: same as `prefix` but work with suffix.
- `prefix?`, `suffix?`: test if the string is the common prefix/suffix between given list of strings. 
- `add-prefix`, `add-suffix`:  as the names suggest.

Thanks.

