### PR TITLE
Add a :limit option for split

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The only dependency is `cl-ppcre`.
             - [unwords `(strings)`](#unwords-strings)
             - [lines `(s)`](#lines-s)
             - [unlines `(strings)`](#unlines-strings)
-            - [split `(separator s &key omit-nulls)`](#split-separator-s-key-omit-nulls)
+            - [split `(separator s &key omit-nulls limit)`](#split-separator-s-key-omit-nulls)
             - [split-omit-nulls  (in v0.6, QL january 2018)](#split-omit-nulls--in-v06-ql-january-2018)
         - [To and from files (experimental in v0.4)](#to-and-from-files-experimental-in-v04)
             - [from-file `(filename)`](#from-file-filename)
@@ -296,7 +296,7 @@ Split string by newline character and return list of lines.
 
 Join the list of strings with a newline character.
 
-#### split `(separator s &key omit-nulls)`
+#### split `(separator s &key omit-nulls limit)`
 
 Split into subtrings (unlike cl-ppcre, without a regexp). If
 `omit-nulls` is non-nil, zero-length substrings are omitted.

--- a/str.lisp
+++ b/str.lisp
@@ -135,8 +135,11 @@
                   string/char
                   (subseq s index)))))
 
-(defun split (separator s &key (omit-nulls *omit-nulls*) (limit nil))
-  "Split s into substring by separator (cl-ppcre takes a regex, we do not)."
+(defun split (separator s &key (omit-nulls *omit-nulls*) limit)
+  "Split s into substring by separator (cl-ppcre takes a regex, we do not).
+
+  `limit` limits the number of elements returned. (i.e. the string is
+  split at most `limit` - 1 times.)"
   ;; cl-ppcre:split doesn't return a null string if the separator appears at the end of s.
   (let* ((res (cl-ppcre:split (cl-ppcre:quote-meta-chars (string separator)) s :limit limit)))
     (if omit-nulls

--- a/str.lisp
+++ b/str.lisp
@@ -135,10 +135,10 @@
                   string/char
                   (subseq s index)))))
 
-(defun split (separator s &key (omit-nulls *omit-nulls*))
+(defun split (separator s &key (omit-nulls *omit-nulls*) (limit nil))
   "Split s into substring by separator (cl-ppcre takes a regex, we do not)."
   ;; cl-ppcre:split doesn't return a null string if the separator appears at the end of s.
-  (let* ((res (cl-ppcre:split (cl-ppcre:quote-meta-chars (string separator)) s)))
+  (let* ((res (cl-ppcre:split (cl-ppcre:quote-meta-chars (string separator)) s :limit limit)))
     (if omit-nulls
         (remove-if (lambda (it) (empty? it)) res)
         res)))

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -48,6 +48,7 @@
   (is '("foo" "bar") (split " " "foo bar"))
   (is '("foo" "bar") (split "+" "foo+bar") "separator is a regexp")
   (is '("foo" "" "bar") (split "+" "foo++bar"))
+  (is '("foo" "bar+car+dar") (split "+" "foo+bar+car+dar" :limit 2))
   (is '("foo" "bar") (split "+" "foo+bar"))
   (is '("foo" "bar") (split "x" "fooxbar") "split with string x")
   (is '("foo" "bar") (split #\x "fooxbar") "split with character")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -57,6 +57,7 @@
   (is '("fooxbar" "x") (split "xx" "fooxbarxxx") "split with xx, end in xxx")
   (is '("foo" "bar") (split "(*)" "foo(*)bar"))
   (is '("foo" "bar") (split "NO" "fooNObarNO") "separator at the end (cl-ppcre doesn't return an empty string).")
+  (is '("foo" "bar" "") (split "NO" "fooNObarNO" :limit 10) "but cl-ppcre does return trailing empty strings if limit is provided")
   (is '("foo" "bar") (split "+" "foo+++bar++++" :omit-nulls t) "omit-nulls argument")
   (is '("foo" "   ") (split "+" "foo+++   ++++" :omit-nulls t) "omit-nulls and blanks")
   (is '("foo" "bar") (let ((*omit-nulls* t)) (split "+" "foo+++bar++++")) "omit-nulls argument")


### PR DESCRIPTION
The limit option is common in most modern split functions, in fact str:words already supports this.