### PR TITLE
Fix the tests

### DIFF
--- a/str.asd
+++ b/str.asd
@@ -9,7 +9,8 @@
   :bug-tracker "https://github.com/vindarel/cl-str/issues"
   :source-control (:git "git@github.com:vindarel/cl-str.git")
   :description "Modern, consistent and terse Common Lisp string manipulation library."
-  :depends-on (:cl-ppcre)
+  :depends-on (:cl-ppcre
+               :cl-ppcre-unicode)
   :components ((:file "str"))
 
   :long-description


### PR DESCRIPTION
In my previous pull request, I found that some tests were
failing. Digging in, I discovered this was due to the lack of
cl-ppcre-unicode. Surprisingly, pulling in cl-ppcre-unicode after
cl-str was loaded didn't fix the issue, so this could be a bad bug
depending on the load order.