### PR TITLE
Add s-count function

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The only dependency is `cl-ppcre`.
             - [replace-all `(old new s)`](#replace-all-old-new-s)
             - [prefix `(list-of-strings)` (renamed in 0.9)](#prefix-list-of-strings-renamed-in-09)
             - [suffix `(list-of-strings)`](#suffix-list-of-strings)
-            - [s-count `(substring s &key start end)`](#s-count-substring-s-key-start-end)
+            - [count-substring `(substring s &key start end)`](#count-substring-substring-s-key-start-end)
     - [Macros](#macros)
         - [string-case](#string-case)
     - [Changelog](#changelog)
@@ -497,17 +497,17 @@ Return a string or nil when the input is the void list.
 
 Find the common suffix between strings.
 
-### s-count `(substring s &key start end)`
+### count-substring `(substring s &key start end)`
 Counts the non-overlapping occurrences of `substring` in `s`.
 You could also count only the ocurrencies between `start` and `end`.
 
 Examples:
 ~~~ lisp
-(s-count "abc" "abcxabcxabc")
+(count-substring "abc" "abcxabcxabc")
 ;; => 3
 ~~~
 ~~~lisp
-(s-count "abc" "abcxabcxabc" :start 3 :end 7)
+(count-substring "abc" "abcxabcxabc" :start 3 :end 7)
 ;; => 1
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -498,7 +498,8 @@ Return a string or nil when the input is the void list.
 Find the common suffix between strings.
 
 ### s-count `(substring s &key start end)`
-Counts the non-overlapping occurrences of `substring` in `s`. You could only count ocurrencies between `start` and `end`.
+Counts the non-overlapping occurrences of `substring` in `s`.
+You could also count only the ocurrencies between `start` and `end`.
 
 Examples:
 ~~~ lisp

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The only dependency is `cl-ppcre`.
             - [replace-all `(old new s)`](#replace-all-old-new-s)
             - [prefix `(list-of-strings)` (renamed in 0.9)](#prefix-list-of-strings-renamed-in-09)
             - [suffix `(list-of-strings)`](#suffix-list-of-strings)
+            - [s-count `(substring s &key start end)`](#s-count-substring-s-key-start-end)
     - [Macros](#macros)
         - [string-case](#string-case)
     - [Changelog](#changelog)
@@ -496,6 +497,18 @@ Return a string or nil when the input is the void list.
 
 Find the common suffix between strings.
 
+### s-count `(substring s &key start end)`
+Counts the non-overlapping occurrences of `substring` in `s`. You could only count ocurrencies between `start` and `end`.
+
+Examples:
+~~~ lisp
+(s-count "abc" "abcxabcxabc")
+;; => 3
+~~~
+~~~lisp
+(s-count "abc" "abcxabcxabc" :start 3 :end 7)
+;; => 1
+~~~
 
 ## Macros
 

--- a/str.lisp
+++ b/str.lisp
@@ -1,4 +1,4 @@
-(in-package :cl-user)
+3(in-package :cl-user)
 (defpackage str
   (:use :cl)
   (:export
@@ -48,6 +48,7 @@
    :s-last
    :s-rest
    :s-nth
+   :s-count
 
    :downcase
    :upcase
@@ -428,6 +429,26 @@ Returns the string written to file."
         ((or (empty? s) (minusp n)) "")
 	((= n 0) (s-first s))
 	(t (s-nth (1- n) (s-rest s)))))
+
+(defun s-count (substring s &key (start 0) (end nil))
+  "Return the non-overlapping occurrences of `substring' in `s'.
+  You could only count ocurrencies between `start' and `end'.
+
+  Examples:
+  (s-count \"abc\" \"abcxabcxabc\")
+  ;; => 3
+
+  (s-count \"abc\" \"abcxabcxabc\" :start 3 :end 7)
+  ;; => 1"
+  (unless (or (null s)
+             (null substring)
+             (empty? substring))
+    (loop :with substring-length := (length substring)
+       :for position := (search substring s :start2 start :end2 end)
+       :then (search substring s :start2 (+ position substring-length) :end2 end)
+       :while (not (null position))
+       :summing 1)))
+
 
 ;;; Case
 

--- a/str.lisp
+++ b/str.lisp
@@ -432,7 +432,7 @@ Returns the string written to file."
 
 (defun s-count (substring s &key (start 0) (end nil))
   "Return the non-overlapping occurrences of `substring' in `s'.
-  You could only count ocurrencies between `start' and `end'.
+  You could also count only the ocurrencies between `start' and `end'.
 
   Examples:
   (s-count \"abc\" \"abcxabcxabc\")

--- a/str.lisp
+++ b/str.lisp
@@ -1,4 +1,4 @@
-3(in-package :cl-user)
+(in-package :cl-user)
 (defpackage str
   (:use :cl)
   (:export

--- a/str.lisp
+++ b/str.lisp
@@ -48,7 +48,7 @@
    :s-last
    :s-rest
    :s-nth
-   :s-count
+   :count-substring
 
    :downcase
    :upcase
@@ -430,15 +430,15 @@ Returns the string written to file."
 	((= n 0) (s-first s))
 	(t (s-nth (1- n) (s-rest s)))))
 
-(defun s-count (substring s &key (start 0) (end nil))
+(defun count-substring (substring s &key (start 0) (end nil))
   "Return the non-overlapping occurrences of `substring' in `s'.
   You could also count only the ocurrencies between `start' and `end'.
 
   Examples:
-  (s-count \"abc\" \"abcxabcxabc\")
+  (count-substring \"abc\" \"abcxabcxabc\")
   ;; => 3
 
-  (s-count \"abc\" \"abcxabcxabc\" :start 3 :end 7)
+  (count-substring \"abc\" \"abcxabcxabc\" :start 3 :end 7)
   ;; => 1"
   (unless (or (null s)
               (null substring)

--- a/str.lisp
+++ b/str.lisp
@@ -441,8 +441,8 @@ Returns the string written to file."
   (s-count \"abc\" \"abcxabcxabc\" :start 3 :end 7)
   ;; => 1"
   (unless (or (null s)
-             (null substring)
-             (empty? substring))
+              (null substring)
+              (empty? substring))
     (loop :with substring-length := (length substring)
        :for position := (search substring s :start2 start :end2 end)
        :then (search substring s :start2 (+ position substring-length) :end2 end)

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -299,16 +299,16 @@
   (is (s-nth 6 "foobar") "")
   (is (s-nth 3 "") ""))
 
-(subtest "s-count"
-  (is (s-count nil nil) nil)
-  (is (s-count "" "abc") nil)
-  (is (s-count "aba" "ababab") 1)
-  (is (s-count "aba" "abababa") 2)
-  (is (s-count "ab" "abxabxab") 3)
-  (is (s-count "cd" "abxabxab") 0)
-  (is (s-count "abcd" "abcd") 1)
-  (is (s-count "abcde" "abcd") 0)
-  (is (s-count "ab" "abxabxab" :start 3 :end 7) 1))
+(subtest "count-substring"
+  (is (count-substring nil nil) nil)
+  (is (count-substring "" "abc") nil)
+  (is (count-substring "aba" "ababab") 1)
+  (is (count-substring "aba" "abababa") 2)
+  (is (count-substring "ab" "abxabxab") 3)
+  (is (count-substring "cd" "abxabxab") 0)
+  (is (count-substring "abcd" "abcd") 1)
+  (is (count-substring "abcde" "abcd") 0)
+  (is (count-substring "ab" "abxabxab" :start 3 :end 7) 1))
 
 (subtest "case"
          (is (downcase nil) nil

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -299,6 +299,15 @@
   (is (s-nth 6 "foobar") "")
   (is (s-nth 3 "") ""))
 
+(subtest "s-count"
+  (is (s-count nil nil) nil)
+  (is (s-count "" "abc") nil)
+  (is (s-count "ab" "abxabxab") 3)
+  (is (s-count "cd" "abxabxab") 0)
+  (is (s-count "abcd" "abcd") 1)
+  (is (s-count "abcde" "abcd") 0)
+  (is (s-count "ab" "abxabxab" :start 3 :end 7) 1))
+
 (subtest "case"
          (is (downcase nil) nil
              "downcase nil returns nil, not a string.")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -302,6 +302,8 @@
 (subtest "s-count"
   (is (s-count nil nil) nil)
   (is (s-count "" "abc") nil)
+  (is (s-count "aba" "ababab") 1)
+  (is (s-count "aba" "abababa") 2)
   (is (s-count "ab" "abxabxab") 3)
   (is (s-count "cd" "abxabxab") 0)
   (is (s-count "abcd" "abcd") 1)


### PR DESCRIPTION
Hello!

This PR adds a new function, `s-count`, which counts the non-overlapping occurrences of a substring in another string. 

**Examples:**
`(s-count "as" "asasas") ; => 3`
`(s-count "as" "asasas" :start 2 :end 4) ; => 1`
`(s-count "asa" "asasas") ; => 1`
`(s-count "asa" "asasasa") ; => 2`