### PR TITLE
Make `split` and `lines` more consistent with other languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,17 +307,6 @@ Split into subtrings (unlike cl-ppcre, without a regexp). If
 (split "+" "foo++bar" :omit-nulls t) ;; => ("foo" "bar")
 ```
 
-It is a wrapper around
-[cl-ppcre:split](https://edicl.github.io/cl-ppcre/#split), so it comes
-with its inconsistency when the separator appears at the end of `s`:
-
-```
-(cl-ppcre:split "," ",a,b,,c,") ;; => ("" "a" "b" "" "c")
-```
-
-it doesn't return a trailing `""`.
-
-
 #### split-omit-nulls  (in v0.6, QL january 2018)
 
 Because it is a common pattern and it can be clearer than an option

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -56,7 +56,7 @@
   (is '("foo" "barx") (split "xx" "fooxxbarx") "split with xx")
   (is '("fooxbar" "x") (split "xx" "fooxbarxxx") "split with xx, end in xxx")
   (is '("foo" "bar") (split "(*)" "foo(*)bar"))
-  (is '("foo" "bar") (split "NO" "fooNObarNO") "separator at the end (cl-ppcre doesn't return an empty string).")
+  (is '("foo" "bar" "") (split "NO" "fooNObarNO") "separator at the end (cl-ppcre doesn't return an empty string), but we do.")
   (is '("foo" "bar" "") (split "NO" "fooNObarNO" :limit 10) "but cl-ppcre does return trailing empty strings if limit is provided")
   (is '("foo" "bar") (split "+" "foo+++bar++++" :omit-nulls t) "omit-nulls argument")
   (is '("foo" "   ") (split "+" "foo+++   ++++" :omit-nulls t) "omit-nulls and blanks")
@@ -165,7 +165,7 @@
 (subtest "Lines"
   (is nil (lines nil))
   (is nil (lines ""))
-  (is nil (lines "
+  (is '("") (lines "
 "))
   (is '("1" "2" " 3") (lines "1
 2


### PR DESCRIPTION
In particular, consistent with Python.

Ever since I noticed this in a previous pull request I sent over, it's been bothering me. I use str:split a lot, and it bothers me that there's this edge case I'm not going to be thinking about.

This of course changes the exposed API, but it seems unlikely that people are depending on this edge case. (Correct me if I'm wrong.)

After fixing `split`, the tests for `lines` obviously broke. But it was easy at that point to make it consistent with python's .splitlines().