### PR TITLE
Add replace-first function

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The only dependency is `cl-ppcre`.
             - [digitp `(s)`](#digitp-s)
             - [has-alpha-p, has-letters-p, has-alphanum-p `(s)`](#has-alpha-p-has-letters-p-has-alphanum-p-s)
         - [Others](#others)
+            - [replace-first `(old new s)`](#replace-first-old-new-s)
             - [replace-all `(old new s)`](#replace-all-old-new-s)
             - [remove-punctuation (s &key replacement)](#remove-punctuation-s-key-replacement)
             - [prefix `(list-of-strings)` (renamed in 0.9)](#prefix-list-of-strings-renamed-in-09)
@@ -560,9 +561,22 @@ Return t if `s` has at least one alpha, letter, alphanum character (as with `alp
 
 ### Others
 
+#### replace-first `(old new s)`
+
+Replace the first occurence of `old` by `new` in `s`. Arguments are not regexs.
+
+
+```cl
+(replace-all "a" "o" "faa") ;; => "foo"
+```
+
+Uses
+[cl-ppcre:regex-replace](http://weitz.de/cl-ppcre/#regex-replace)
+but quotes the user input to not treat it as a regex.
+
 #### replace-all `(old new s)`
 
-Replace `old` by `new` (no regexs) in `s`.
+Replace all occurences of `old` by `new` in `s`. Arguments are not regexs.
 
 ```cl
 (replace-all "a" "o" "faa") ;; => "foo"

--- a/str.lisp
+++ b/str.lisp
@@ -47,6 +47,7 @@
    :shorten
    :prune ;; "deprecated" in favor of shorten
    :repeat
+   :replace-first
    :replace-all
    :concat
    :empty?
@@ -277,8 +278,14 @@ It uses `subseq' with differences:
       (setf result (cons s result)))
     (apply #'concat result)))
 
+(defun replace-first (old new s)
+  "Replace the first occurence of `old` by `new` in `s`. Arguments are not regexs."
+  (let* ((cl-ppcre:*allow-quoting* t)
+         (old (concatenate 'string  "\\Q" old))) ;; treat metacharacters as normal.
+    (cl-ppcre:regex-replace old s new)))
+
 (defun replace-all (old new s)
-  "Replace `old` by `new` in `s`. Arguments are not regexs."
+  "Replace all occurences of `old` by `new` in `s`. Arguments are not regexs."
   (let* ((cl-ppcre:*allow-quoting* t)
          (old (concatenate 'string  "\\Q" old))) ;; treat metacharacters as normal.
     (cl-ppcre:regex-replace-all old s new)))

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -29,7 +29,8 @@
 (subtest "Replace"
   (is "foo" (replace-all "a" "o" "faa"))
   (is "foo" (replace-all "^a" "o" "fo^a"))
-  (is "foo" (replace-all "^aa+" "o" "fo^aa+")))
+  (is "foo" (replace-all "^aa+" "o" "fo^aa+"))
+  (is "fooaa" (replace-first "aa" "oo" "faaaa")))
 
 (subtest "Join"
   (is "foo bar baz" (join " " '("foo" "bar" "baz")))


### PR DESCRIPTION
Hi :) I've been using both `replace-all` and `regex-replace` from cl-ppcre. `regex-replace` replaces only the first occurrence of a certain string, so I thought about implementing it in this library so I can use both functions more similarly.