### PR TITLE
Make trim* functions nil-aware

### DIFF
--- a/str.lisp
+++ b/str.lisp
@@ -139,18 +139,21 @@
 
 (defun trim-left (s)
   "Remove whitespaces at the beginning of s. "
-  (string-left-trim *whitespaces* s))
+  (when s
+    (string-left-trim *whitespaces* s)))
 
 (defun trim-right (s)
   "Remove whitespaces at the end of s."
-  (string-right-trim *whitespaces* s))
+  (when s
+    (string-right-trim *whitespaces* s)))
 
 (defun trim (s)
   "Remove whitespaces at the beginning and end of s.
 @begin[lang=lisp](code)
 (trim \"  foo \") ;; => \"foo\"
 @end(code)"
-  (string-trim *whitespaces* s))
+  (when s
+    (string-trim *whitespaces* s)))
 
 (defun collapse-whitespaces (s)
   "Ensure there is only one space character between words.

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -12,7 +12,10 @@
 (subtest "Trim"
   (is "rst " (trim-left "   rst "))
   (is " rst" (trim-right " rst   "))
-  (is "rst" (trim "  rst  ")))
+  (is "rst" (trim "  rst  "))
+  (is nil (trim-left nil))
+  (is nil (trim-right nil))
+  (is nil (trim nil)))
 
 (subtest "Collapse whitespaces"
   (is "foo bar baz" (collapse-whitespaces "foo  bar


### PR DESCRIPTION
Literally nobody wants (trim nil) to produce a "NIL" string. Adding a
check to ensure that nil is returned in such case.