### PR TITLE
Introduce RSPLIT, similar to python's str.rsplit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The only dependency is `cl-ppcre`.
             - [lines `(s &key omit-nulls)`](#lines-s-key-omit-nulls)
             - [unlines `(strings)`](#unlines-strings)
             - [split `(separator s &key omit-nulls limit start end)`](#split-separator-s-key-omit-nulls-limit-start-end)
+            - [rsplit `(separator s &key limit)`](#rsplit-separator-s-key-limit)
             - [split-omit-nulls](#split-omit-nulls)
         - [To and from files](#to-and-from-files)
             - [from-file `(filename)`](#from-file-filename)
@@ -379,6 +380,17 @@ Split into subtrings (unlike cl-ppcre, without a regexp). If
 cl-ppcre has an inconsistency such that when the separator appears at
 the end, it doesn't return a trailing empty string. But we do **since
 v0.14** (october, 2019).
+
+#### rsplit `(separator s &key limit)`
+
+Similar to `split`, but split from the end. In particular, this will
+be different from `split` when a `:limit` is provided, but in more
+obscure cases it can be different when there are multiple different
+ways to split the string.
+
+```lisp
+(rsplit "/" "/var/log/mail.log" :limit 2) ;; => ("/var/log" "mail.log")
+```
 
 ~~~lisp
 (cl-ppcre:split " " "a b c ")

--- a/str.lisp
+++ b/str.lisp
@@ -43,6 +43,7 @@
    :join
    :insert
    :split
+   :rsplit
    :split-omit-nulls
    :substring
    :shorten
@@ -209,6 +210,15 @@
     (if omit-nulls
         (remove-if (lambda (it) (empty? it)) res)
         res)))
+
+(defun rsplit (sep s &key (omit-nulls *omit-nulls*) limit)
+  "Similar to `split`, example we split from the end. In particular,
+the results will be be different when `limit` is provided."
+  (nreverse
+   (mapcar 'nreverse
+           (split (reverse (string sep)) (reverse s)
+                  :omit-nulls omit-nulls
+                  :limit limit))))
 
 (defun split-omit-nulls (separator s)
   "Call split with :omit-nulls to t.

--- a/str.lisp
+++ b/str.lisp
@@ -212,7 +212,7 @@
         res)))
 
 (defun rsplit (sep s &key (omit-nulls *omit-nulls*) limit)
-  "Similar to `split`, example we split from the end. In particular,
+  "Similar to `split`, except we split from the end. In particular,
 the results will be be different when `limit` is provided."
   (nreverse
    (mapcar 'nreverse

--- a/str.lisp
+++ b/str.lisp
@@ -206,7 +206,7 @@
   split at most `limit' - 1 times)."
   ;; cl-ppcre:split doesn't return a null string if the separator appears at the end of s.
   (let* ((limit (or limit (1+ (length s))))
-         (res (ppcre:split (ppcre:quote-meta-chars (string separator)) s :limit limit :start start :end end)))
+         (res (ppcre:split `(:sequence ,(string separator)) s :limit limit :start start :end end)))
     (if omit-nulls
         (remove-if (lambda (it) (empty? it)) res)
         res)))

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -80,14 +80,18 @@
   (is '("foo" "   ") (split "+" "foo+++   ++++" :omit-nulls t) "omit-nulls and blanks")
   (is '("foo" "bar") (let ((*omit-nulls* t)) (split "+" "foo+++bar++++")) "omit-nulls argument")
   (is '("foo" "   ") (let ((*omit-nulls* t)) (split "+" "foo+++   ++++")) "omit-nulls and blanks")
-         (is '("foo" "bar") (split #\, "foo,bar")))
+  (is '("foo" "bar") (split #\, "foo,bar")))
 
 
 (subtest "rsplit"
   (is '("foo" "bar") (rsplit " " "foo bar"))
   (is '("foo" "bar") (rsplit #\, "foo,bar"))
   (is '("com.foo" "Bar") (rsplit "." "com.foo.Bar" :limit 2))
-  (is '("/var/log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 2)))
+  (is '("/var/log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 2))
+  (is '("/var" "log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 3))
+  (is '("" "var" "log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 4))
+  (is '("foo" "bar") (rsplit "LONG" "fooLONGbar"))
+  (is '("foo" "bar" "") (rsplit "LONG" "fooLONGbarLONG")))
 
 (subtest "substring"
   (is "abcd" (substring 0 4 "abcd") "normal case")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -81,9 +81,7 @@
   (is '("foo" "bar") (let ((*omit-nulls* t)) (split "+" "foo+++bar++++")) "omit-nulls argument")
   (is '("foo" "   ") (let ((*omit-nulls* t)) (split "+" "foo+++   ++++")) "omit-nulls and blanks")
   (is '("foo" "bar") (split #\, "foo,bar"))
-  (is '("foo" "ABbar") (split "ABAB" "fooABABABbar"))
-  )
-
+  (is '("foo" "ABbar") (split "ABAB" "fooABABABbar")))
 
 (subtest "rsplit"
   (is '("foo" "bar") (rsplit " " "foo bar"))

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -80,7 +80,9 @@
   (is '("foo" "   ") (split "+" "foo+++   ++++" :omit-nulls t) "omit-nulls and blanks")
   (is '("foo" "bar") (let ((*omit-nulls* t)) (split "+" "foo+++bar++++")) "omit-nulls argument")
   (is '("foo" "   ") (let ((*omit-nulls* t)) (split "+" "foo+++   ++++")) "omit-nulls and blanks")
-  (is '("foo" "bar") (split #\, "foo,bar")))
+  (is '("foo" "bar") (split #\, "foo,bar"))
+  (is '("foo" "ABbar") (split "ABAB" "fooABABABbar"))
+  )
 
 
 (subtest "rsplit"
@@ -91,7 +93,8 @@
   (is '("/var" "log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 3))
   (is '("" "var" "log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 4))
   (is '("foo" "bar") (rsplit "LONG" "fooLONGbar"))
-  (is '("foo" "bar" "") (rsplit "LONG" "fooLONGbarLONG")))
+  (is '("foo" "bar" "") (rsplit "LONG" "fooLONGbarLONG" :limit 3))
+  (is '("fooAB" "bar") (rsplit "ABAB" "fooABABABbar")))
 
 (subtest "substring"
   (is "abcd" (substring 0 4 "abcd") "normal case")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -80,7 +80,14 @@
   (is '("foo" "   ") (split "+" "foo+++   ++++" :omit-nulls t) "omit-nulls and blanks")
   (is '("foo" "bar") (let ((*omit-nulls* t)) (split "+" "foo+++bar++++")) "omit-nulls argument")
   (is '("foo" "   ") (let ((*omit-nulls* t)) (split "+" "foo+++   ++++")) "omit-nulls and blanks")
-  (is '("foo" "bar") (split #\, "foo,bar")))
+         (is '("foo" "bar") (split #\, "foo,bar")))
+
+
+(subtest "rsplit"
+  (is '("foo" "bar") (rsplit " " "foo bar"))
+  (is '("foo" "bar") (rsplit #\, "foo,bar"))
+  (is '("com.foo" "Bar") (rsplit "." "com.foo.Bar" :limit 2))
+  (is '("/var/log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 2)))
 
 (subtest "substring"
   (is "abcd" (substring 0 4 "abcd") "normal case")


### PR DESCRIPTION
There are many cases where rsplit is useful: dealing with directory strings, (and in my case) dealing with java style package names.

(PS. Is the algorithm I used correct? I think it is, but there may be an edge case that I haven't thought of)