### PR TITLE
Add README.md as dependency

### DIFF
--- a/str.asd
+++ b/str.asd
@@ -12,7 +12,8 @@
   :depends-on (:cl-ppcre
                :cl-ppcre-unicode
                :cl-change-case)
-  :components ((:file "str"))
+  :components ((:file "str")
+               (:static-file "README.md"))
 
   :long-description
   #.(uiop:read-file-string


### PR DESCRIPTION
I was trying to include str as part of an abcl jar. asdf-jar removed
any unneeded files such as licenses and documentation. Should be okay,
but str.asd reads from README.md at read time, thus it needs to be
present in order to load str.