### PR TITLE
Ensure functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ The only dependency is `cl-ppcre`.
             - [contains?, containsp `(substring s &key (ignore-case nil))`](#contains-containsp-substring-s-key-ignore-case-nil)
             - [s-member `(list s &key (ignore-case *ignore-case*) (test #'string=))`](#s-member-list-s-key-ignore-case-ignore-case-test-string)
             - [prefix?, prefixp and suffix?, suffixp `(items s)`](#prefix-prefixp-and-suffix-suffixp-items-s)
+            - [ensure-starts-with, ensure-ends-with `(start/end s)` NEW in June, 2022](#ensure-starts-with-ensure-ends-with-startend-s-new-in-june-2022)
+            - [ensure-enclosed-by `(start/end s)`](#ensure-enclosed-by-startend-s)
         - [Case](#case)
-            - [Functions to change case: camel-case, snake-case,... (new in 0.15, 2019/11)](#functions-to-change-case-camel-case-snake-case-new-in-015-201911)
-            - [downcase, upcase, capitalize `(s)` fixing a built-in suprise. (new in 0.11)](#downcase-upcase-capitalize-s-fixing-a-built-in-suprise-new-in-011)
+            - [Functions to change case: camel-case, snake-case,...](#functions-to-change-case-camel-case-snake-case)
+            - [downcase, upcase, capitalize `(s)` fixing a built-in suprise.](#downcase-upcase-capitalize-s-fixing-a-built-in-suprise)
             - [downcasep, upcasep `(s)`](#downcasep-upcasep-s)
             - [alphap, lettersp `(s)`](#alphap-lettersp-s)
             - [alphanump, lettersnump `(s)`](#alphanump-lettersnump-s)
@@ -565,9 +567,32 @@ See also `uiop:string-prefix-p prefix s`, which returns `t` if
 and `uiop:string-enclosed-p prefix s suffix`, which returns `t` if `s`
 begins with `prefix` and ends with `suffix`.
 
+#### ensure-starts-with, ensure-ends-with `(start/end s)` NEW in June, 2022
+
+Ensure that `s` starts with `start` (or ends with `end`).
+
+Return a new string with its prefix added, if necessary.
+
+Example:
+
+~~~lisp
+(str:ensure-starts-with "/" "abc/") => "/abc/"
+~~~
+
+#### ensure-enclosed-by `(start/end s)`
+
+Ensure that `s` both starts and ends with `start/end`.
+
+Return a new string with the necessary added bits, if required.
+
+It simply calls `str:ensure-ends-with` followed by `str:ensure-starts-with`.
+
+See also `uiop:string-enclosed-p prefix s suffix`.
+
+
 ### Case
 
-#### Functions to change case: camel-case, snake-case,... (new in 0.15, 2019/11)
+#### Functions to change case: camel-case, snake-case,...
 
 We use
 [cl-change-case](https://github.com/rudolfochrist/cl-change-case/) (go
@@ -593,7 +618,7 @@ The available functions are:
 More documentation and examples are there.
 
 
-#### downcase, upcase, capitalize `(s)` fixing a built-in suprise. (new in 0.11)
+#### downcase, upcase, capitalize `(s)` fixing a built-in suprise.
 
 The functions `str:downcase`, `str:upcase` and `str:capitalize` return
 a new string. They call the built-in `string-downcase`,
@@ -797,7 +822,9 @@ Note that there is also http://quickdocs.org/string-case/.
 
 ## Changelog
 
-* June, 2022: small breaking change: fixed `prefix?` when used with a smaller prefix: "f" was not recognized as a prefix of "foobar" and "foobuz", only "foo" was. Now it is fixed. Same for `suffix?`.
+* June, 2022:
+  * added `str:ensure-starts-with`, `str:ensure-ends-with`, `str:ensure-enclosed-by`
+  * small breaking change: fixed `prefix?` when used with a smaller prefix: "f" was not recognized as a prefix of "foobar" and "foobuz", only "foo" was. Now it is fixed. Same for `suffix?`.
 * Feb, 2022: added `fit`: fit the string to the given length: either shorten it, either padd padding.
 * 0.20, May, 2021: added `ascii-p`.
 * 0.19.1, May, 2021: speed up `join` (by a factor of 4).

--- a/README.md
+++ b/README.md
@@ -574,18 +574,44 @@ See also `uiop:string-prefix-p prefix s`, which returns `t` if
 and `uiop:string-enclosed-p prefix s suffix`, which returns `t` if `s`
 begins with `prefix` and ends with `suffix`.
 
-#### ensure-start, ensure-end `(start/end s)` NEW in February, 2023
+#### ensure `(s &key wrapped-in prefix suffix)` NEW in March, 2023
 
-Ensure that `s` starts with `start` (or ends with `end`).
+The "ensure-" functions return a string that has the specified prefix or suffix, appended if necessary.
 
-Return a new string with its prefix added, if necessary.
+This `str:ensure` function looks for the following key parameters, in order:
+
+- `:wrapped-in`: if non nil, call `str:ensure-wrapped-in`. This checks that `s` both starts and ends with the supplied string or character.
+- `:prefix` and `:suffix`: if both are supplied and non-nil, call `str:ensure-suffix` followed by `str:ensure-prefix`.
+- `:prefix`: call `str:ensure-prefix`
+- `:suffix`: call `str:ensure-suffix`.
 
 Example:
 
 ~~~lisp
-(str:ensure-start "/" "abc/") => "/abc/"
+(str:ensure "abc" :wrapped-in "/")  ;; => "/abc/"
+(str:ensure "/abc" :prefix "/")  ;; => "/abc"  => no change, still one "/"
+(str:ensure "/abc" :suffix "/")  ;; => "/abc/" => added a "/" suffix.
+~~~
+
+These fonctions accept strings and characters:
+
+~~~lisp
+(str:ensure "/abc" :prefix #\/)
+~~~
+
+
+### ensure-prefix, ensure-suffix `(start/end s)` NEW in March, 2023
+
+Ensure that `s` starts with `start/end` (or ends with `start/end`, respectively).
+
+Return a new string with its prefix (or suffix) added, if and only if necessary.
+
+Example:
+
+~~~lisp
+(str:ensure-prefix "/" "abc/") => "/abc/" (a prefix was added)
 ;; and
-(str:ensure-start "/" "/abc/") => "/abc/" (does nothing)
+(str:ensure-prefix "/" "/abc/") => "/abc/" (does nothing)
 ~~~
 
 #### ensure-wrapped-in `(start/end s)`
@@ -594,9 +620,14 @@ Ensure that `s` both starts and ends with `start/end`.
 
 Return a new string with the necessary added bits, if required.
 
-It simply calls `str:ensure-end` followed by `str:ensure-start`.
+It simply calls `str:ensure-suffix` followed by `str:ensure-prefix`.
 
 See also `str:wrapped-in-p` and `uiop:string-enclosed-p prefix s suffix`.
+
+~~~lisp
+(str:ensure-wrapped-in "/" "abc") ;; => "/abc/"  (added both a prefix and a suffix)
+(str:ensure-wrapped-in "/" "/abc/") ;; => "/abc/" (does nothing)
+~~~
 
 
 ### Case
@@ -831,8 +862,8 @@ Note that there is also http://quickdocs.org/string-case/.
 
 ## Changelog
 
-* February, 2023:
-  * added `str:ensure-start`, `str:ensure-end`, `str:ensure-wrapped-in`
+* March, 2023:
+  * added `str:ensure`, `str:ensure-prefix`, `str:ensure-suffix` and `str:ensure-wrapped-in`
   * small breaking change: fixed `prefix?` when used with a smaller prefix: "f" was not recognized as a prefix of "foobar" and "foobuz", only "foo" was. Now it is fixed. Same for `suffix?`.
 * January, 2023: added the `:char-barg` parameter to `trim`, `trim-left`, `trim-right`.
   - minor: `ends-with-p` now works with a character.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The only dependency is `cl-ppcre`.
             - [contains?, containsp `(substring s &key (ignore-case nil))`](#contains-containsp-substring-s-key-ignore-case-nil)
             - [s-member `(list s &key (ignore-case *ignore-case*) (test #'string=))`](#s-member-list-s-key-ignore-case-ignore-case-test-string)
             - [prefix?, prefixp and suffix?, suffixp `(items s)`](#prefix-prefixp-and-suffix-suffixp-items-s)
-            - [ensure-starts-with, ensure-ends-with `(start/end s)` NEW in June, 2022](#ensure-starts-with-ensure-ends-with-startend-s-new-in-june-2022)
-            - [ensure-enclosed-by `(start/end s)`](#ensure-enclosed-by-startend-s)
+            - [ensure-start, ensure-end `(start/end s)` NEW in February, 2023](#ensure-start-ensure-end-startend-s-new-in-february-2023)
+            - [ensure-wrapped-in `(start/end s)`](#ensure-wrapped-in-startend-s)
         - [Case](#case)
             - [Functions to change case: camel-case, snake-case,...](#functions-to-change-case-camel-case-snake-case)
             - [downcase, upcase, capitalize `(s)` fixing a built-in suprise.](#downcase-upcase-capitalize-s-fixing-a-built-in-suprise)
@@ -567,7 +567,7 @@ See also `uiop:string-prefix-p prefix s`, which returns `t` if
 and `uiop:string-enclosed-p prefix s suffix`, which returns `t` if `s`
 begins with `prefix` and ends with `suffix`.
 
-#### ensure-starts-with, ensure-ends-with `(start/end s)` NEW in June, 2022
+#### ensure-start, ensure-end `(start/end s)` NEW in February, 2023
 
 Ensure that `s` starts with `start` (or ends with `end`).
 
@@ -576,18 +576,20 @@ Return a new string with its prefix added, if necessary.
 Example:
 
 ~~~lisp
-(str:ensure-starts-with "/" "abc/") => "/abc/"
+(str:ensure-start "/" "abc/") => "/abc/"
+;; and
+(str:ensure-start "/" "/abc/") => "/abc/" (does nothing)
 ~~~
 
-#### ensure-enclosed-by `(start/end s)`
+#### ensure-wrapped-in `(start/end s)`
 
 Ensure that `s` both starts and ends with `start/end`.
 
 Return a new string with the necessary added bits, if required.
 
-It simply calls `str:ensure-ends-with` followed by `str:ensure-starts-with`.
+It simply calls `str:ensure-end` followed by `str:ensure-start`.
 
-See also `uiop:string-enclosed-p prefix s suffix`.
+See also `str:wrapped-in-p` and `uiop:string-enclosed-p prefix s suffix`.
 
 
 ### Case
@@ -823,7 +825,7 @@ Note that there is also http://quickdocs.org/string-case/.
 ## Changelog
 
 * June, 2022:
-  * added `str:ensure-starts-with`, `str:ensure-ends-with`, `str:ensure-enclosed-by`
+  * added `str:ensure-start`, `str:ensure-end`, `str:ensure-wrapped-in`
   * small breaking change: fixed `prefix?` when used with a smaller prefix: "f" was not recognized as a prefix of "foobar" and "foobuz", only "foo" was. Now it is fixed. Same for `suffix?`.
 * Feb, 2022: added `fit`: fit the string to the given length: either shorten it, either padd padding.
 * 0.20, May, 2021: added `ascii-p`.

--- a/str.lisp
+++ b/str.lisp
@@ -78,9 +78,9 @@
    :suffixp
    :add-prefix
    :add-suffix
-   :ensure-starts-with
-   :ensure-ends-with
-   :ensure-enclosed-by
+   :ensure-start
+   :ensure-end
+   :ensure-wrapped-in
    :enclosed-by-p
 
    :pad
@@ -494,16 +494,16 @@ A simple call to the built-in `search` (which returns the position of the substr
   "Append s to the end of eahc items."
   (mapcar #'(lambda (item) (concat item s)) items))
 
-(defun ensure-starts-with (start s)
+(defun ensure-start (start s)
   "Ensure that `s' starts with `start'.
   Return a new string with its prefix added, if necessary.
 
 Example:
 
-  (str:ensure-starts-with \"/\" \"abc/\") ;; => \"/abc/\"
-  (str:ensure-starts-with \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+  (str:ensure-start \"/\" \"abc/\") ;; => \"/abc/\"
+  (str:ensure-start \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
-See also `str:ensure-ends-with' and `str:ensure-enclosed-by'."
+See also `str:ensure-end' and `str:ensure-wrapped-in'."
   (cond
     ((null start)
      s)
@@ -515,16 +515,16 @@ See also `str:ensure-ends-with' and `str:ensure-enclosed-by'."
            (str:concat start-s s)
            s)))))
 
-(defun ensure-ends-with (end s)
+(defun ensure-end (end s)
   "Ensure that `s' ends with `end'.
 Return a new string with its suffix added, if necessary.
 
 Example:
 
-  (str:ensure-ends-with \"/\" \"/abc\") ;; => \"/abc/\"
-  (str:ensure-ends-with \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+  (str:ensure-end \"/\" \"/abc\") ;; => \"/abc/\"
+  (str:ensure-end \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
-See also `str:ensure-starts-with' and `str:ensure-enclosed-by'."
+See also `str:ensure-start' and `str:ensure-wrapped-in'."
   (cond
     ((null end)
      s)
@@ -536,20 +536,20 @@ See also `str:ensure-starts-with' and `str:ensure-enclosed-by'."
            (str:concat s end-s)
            s)))))
 
-(defun ensure-enclosed-by (start/end s)
+(defun ensure-wrapped-in (start/end s)
   "Ensure that S starts and ends with `START/END'.
 Return a new string.
 
   Example:
 
-    (str:ensure-enclosed-by \"/\" \"abc\") ;; => \"/abc/\"
-    (str:ensure-enclosed-by \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+    (str:ensure-wrapped-in \"/\" \"abc\") ;; => \"/abc/\"
+    (str:ensure-wrapped-in \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
   See also: `str:enclosed-by-p'."
-  (str:ensure-starts-with start/end (str:ensure-ends-with start/end s)))
+  (str:ensure-start start/end (str:ensure-end start/end s)))
 
-(defun enclosed-by-p (start/end s)
-  "Does S starts and ends with `START/END'?
+(defun wrapped-in-p (start/end s)
+  "Does S start and end with `START/END'?
 If true, return S. Otherwise, return nil.
 
 Example:

--- a/str.lisp
+++ b/str.lisp
@@ -78,6 +78,10 @@
    :suffixp
    :add-prefix
    :add-suffix
+   :ensure-starts-with
+   :ensure-ends-with
+   :ensure-enclosed-by
+
    :pad
    :pad-left
    :pad-right
@@ -488,6 +492,39 @@ A simple call to the built-in `search` (which returns the position of the substr
 (defun add-suffix (items s)
   "Append s to the end of eahc items."
   (mapcar #'(lambda (item) (concat item s)) items))
+
+(defun ensure-starts-with (start s)
+  "Ensure that `s' starts with `start'.
+  Return a new string with its prefix added, if necessary.
+
+  Example: (str:ensure-starts-with \"/\" \"abc/\") => \"/abc/\"
+
+  See also `str:ensure-ends-with' and `str:ensure-enclosed-by'."
+  (when start
+    (let ((start-s (string start)))
+      (if (not (str:starts-with-p start-s s))
+          (str:concat start-s s)
+          s))))
+
+(defun ensure-ends-with (end s)
+  "Ensure that `s' ends with `end'.
+  Return a new string with its suffix added, if necessary.
+
+  Example: (str:ensure-ends-with \"/\" \"/abc\") => \"/abc/\"
+
+  See also `str:ensure-starts-with' and `str:ensure-enclosed-by'."
+  (when end
+    (let ((end-s (string end)))
+      (if (not (str:ends-with-p end-s s))
+          (str:concat s end-s)
+          s))))
+
+(defun ensure-enclosed-by (start/end s)
+  "Ensure that S starts and ends with `START/END'.
+  Return a new string.
+
+  See also `UIOP:STRING-ENCLOSED-P PREFIX S SUFFIX`."
+  (str:ensure-starts-with start/end (str:ensure-ends-with start/end s)))
 
 (defun pad (len s &key (pad-side *pad-side*) (pad-char *pad-char*))
   "Fill `s' with characters until it is of the given length. By default, add spaces on the right.

--- a/str.lisp
+++ b/str.lisp
@@ -68,6 +68,7 @@
   #:suffixp
   #:add-prefix
   #:add-suffix
+  #:ensure-start
   #:ensure-end
   #:ensure-wrapped-in
   #:wrapped-in-p

--- a/str.lisp
+++ b/str.lisp
@@ -81,6 +81,7 @@
    :ensure-starts-with
    :ensure-ends-with
    :ensure-enclosed-by
+   :enclosed-by-p
 
    :pad
    :pad-left
@@ -546,6 +547,28 @@ Return a new string.
 
   See also: `str:enclosed-by-p'."
   (str:ensure-starts-with start/end (str:ensure-ends-with start/end s)))
+
+(defun enclosed-by-p (start/end s)
+  "Does S starts and ends with `START/END'?
+If true, return S. Otherwise, return nil.
+
+Example:
+
+    (str:enclosed-by-p \"/\" \"/foo/\"  ;; => \"/foo/\"
+    (str:enclosed-by-p \"/\" \"/foo\"  ;; => nil
+
+See also: UIOP:STRING-ENCLOSED-P (prefix s suffix).
+"
+  (cond
+    ((null start/end)
+     s)
+    ((null s)
+     s)
+    (t
+     ;; (starts-with-p nil "foo") returns NIL.
+     (when (and (str:starts-with-p start/end s)
+                (str:ends-with-p start/end s))
+       s))))
 
 (defun pad (len s &key (pad-side *pad-side*) (pad-char *pad-char*))
   "Fill `s' with characters until it is of the given length. By default, add spaces on the right.

--- a/str.lisp
+++ b/str.lisp
@@ -477,7 +477,7 @@ A simple call to the built-in `search` (which returns the position of the substr
 
 (defun suffix? (items suffix)
   "Return `suffix' if all items end with it.
-  Otherwise, retur nil"
+  Otherwise, return nil"
   (when (every (lambda (s)
                (str:ends-with-p suffix s))
              items)
@@ -497,33 +497,54 @@ A simple call to the built-in `search` (which returns the position of the substr
   "Ensure that `s' starts with `start'.
   Return a new string with its prefix added, if necessary.
 
-  Example: (str:ensure-starts-with \"/\" \"abc/\") => \"/abc/\"
+Example:
 
-  See also `str:ensure-ends-with' and `str:ensure-enclosed-by'."
-  (when start
-    (let ((start-s (string start)))
-      (if (not (str:starts-with-p start-s s))
-          (str:concat start-s s)
-          s))))
+  (str:ensure-starts-with \"/\" \"abc/\") ;; => \"/abc/\"
+  (str:ensure-starts-with \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+
+See also `str:ensure-ends-with' and `str:ensure-enclosed-by'."
+  (cond
+    ((null start)
+     s)
+    ((null s)
+     s)
+    (t
+     (let ((start-s (string start)))
+       (if (not (str:starts-with-p start-s s))
+           (str:concat start-s s)
+           s)))))
 
 (defun ensure-ends-with (end s)
   "Ensure that `s' ends with `end'.
-  Return a new string with its suffix added, if necessary.
+Return a new string with its suffix added, if necessary.
 
-  Example: (str:ensure-ends-with \"/\" \"/abc\") => \"/abc/\"
+Example:
 
-  See also `str:ensure-starts-with' and `str:ensure-enclosed-by'."
-  (when end
-    (let ((end-s (string end)))
-      (if (not (str:ends-with-p end-s s))
-          (str:concat s end-s)
-          s))))
+  (str:ensure-ends-with \"/\" \"/abc\") ;; => \"/abc/\"
+  (str:ensure-ends-with \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+
+See also `str:ensure-starts-with' and `str:ensure-enclosed-by'."
+  (cond
+    ((null end)
+     s)
+    ((null s)
+     s)
+    (t
+     (let ((end-s (string end)))
+       (if (not (str:ends-with-p end-s s))
+           (str:concat s end-s)
+           s)))))
 
 (defun ensure-enclosed-by (start/end s)
   "Ensure that S starts and ends with `START/END'.
-  Return a new string.
+Return a new string.
 
-  See also `UIOP:STRING-ENCLOSED-P PREFIX S SUFFIX`."
+  Example:
+
+    (str:ensure-enclosed-by \"/\" \"abc\") ;; => \"/abc/\"
+    (str:ensure-enclosed-by \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+
+  See also: `str:enclosed-by-p'."
   (str:ensure-starts-with start/end (str:ensure-ends-with start/end s)))
 
 (defun pad (len s &key (pad-side *pad-side*) (pad-char *pad-char*))

--- a/str.lisp
+++ b/str.lisp
@@ -542,6 +542,37 @@ Return a new string.
   See also: `str:enclosed-by-p'."
   (str:ensure-start start/end (str:ensure-end start/end s)))
 
+(defun ensure (s &key wrapped-in prefix suffix)
+  "The ensure functions return a string that has the specified prefix or suffix, appened if necessary.
+
+This function looks for the following parameters, in order:
+- :wrapped-in : if non nil, call STR:ENSURE-WRAPPED-IN.
+- :prefix and :suffix : if both are supplied and non-nil, call STR:ENSURE-SUFFIX followed by STR:ENSURE-PREFIX.
+- :prefix : call STR:ENSURE-PREFIX
+- :suffix : call STR:ENSURE-SUFFIX.
+
+Example:
+
+    (str:ensure \"abc\" :wrapped-in \"/\")  ;; => \"/abc/\"
+    (str:ensure \"/abc\" :prefix \"/\")  ;; => \"/abc\"  (no change, still one \"/\")
+    (str:ensure \"/abc\" :suffix \"/\")  ;; => \"/abc/\"  (added a \"/\" suffix)
+
+    These fonctions accept strings and characters:
+
+    (str:ensure \"/abc\" :prefix #\\/)
+"
+  (cond
+    (wrapped-in
+     (ensure-wrapped-in wrapped-in s))
+    ((and prefix suffix)
+     (ensure-prefix prefix (ensure-suffix suffix s)))
+    (prefix
+     (ensure-prefix prefix s))
+    (suffix
+     (ensure-suffix suffix s))
+    (t
+     s)))
+
 (defun wrapped-in-p (start/end s)
   "Does S start and end with `START/END'?
 If true, return S. Otherwise, return nil.

--- a/str.lisp
+++ b/str.lisp
@@ -546,7 +546,7 @@ Return a new string.
   (str:ensure-prefix start/end (str:ensure-suffix start/end s)))
 
 (defun ensure (s &key wrapped-in prefix suffix)
-  "The ensure functions return a string that has the specified prefix or suffix, appened if necessary.
+  "The ensure functions return a string that has the specified prefix or suffix, appended if necessary.
 
 This function looks for the following parameters, in order:
 - :wrapped-in : if non nil, call STR:ENSURE-WRAPPED-IN.

--- a/str.lisp
+++ b/str.lisp
@@ -395,10 +395,12 @@ It uses `subseq' with differences:
 (setf (fdefinition 'starts-with-p) #'starts-with?)
 
 (defun ends-with? (end s &key (ignore-case *ignore-case*))
-  "Return t if s ends with the substring 'end', nil otherwise."
-  (when (>= (length s) (length end))
+  "Return t if S ends with the substring `END', nil otherwise.
+
+  END can be a character or a string."
+  (when (>= (length s) (length (string end)))
     (let ((fn (if ignore-case #'string-equal #'string=)))
-      (funcall fn s end :start1 (- (length s) (length end))))))
+      (funcall fn s end :start1 (- (length s) (length (string end)))))))
 
 (setf (fdefinition 'ends-with-p) #'ends-with?)
 

--- a/str.lisp
+++ b/str.lisp
@@ -68,10 +68,13 @@
   #:suffixp
   #:add-prefix
   #:add-suffix
-  #:ensure-start
-  #:ensure-end
+
+  #:ensure
+  #:ensure-prefix
+  #:ensure-suffix
   #:ensure-wrapped-in
   #:wrapped-in-p
+
   #:pad
   #:pad-left
   #:pad-right
@@ -488,16 +491,16 @@ A simple call to the built-in `search` (which returns the position of the substr
   "Append s to the end of eahc items."
   (mapcar #'(lambda (item) (concat item s)) items))
 
-(defun ensure-start (start s)
+(defun ensure-prefix (start s)
   "Ensure that `s' starts with `start'.
   Return a new string with its prefix added, if necessary.
 
 Example:
 
-  (str:ensure-start \"/\" \"abc/\") ;; => \"/abc/\"
-  (str:ensure-start \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+  (str:ensure-prefix \"/\" \"abc/\") ;; => \"/abc/\"
+  (str:ensure-prefix \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
-See also `str:ensure-end' and `str:ensure-wrapped-in'."
+See also `str:ensure-suffix' and `str:ensure-wrapped-in'."
   (cond
     ((null start)
      s)
@@ -509,16 +512,16 @@ See also `str:ensure-end' and `str:ensure-wrapped-in'."
            (str:concat start-s s)
            s)))))
 
-(defun ensure-end (end s)
+(defun ensure-suffix (end s)
   "Ensure that `s' ends with `end'.
 Return a new string with its suffix added, if necessary.
 
 Example:
 
-  (str:ensure-end \"/\" \"/abc\") ;; => \"/abc/\"
-  (str:ensure-end \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
+  (str:ensure-suffix \"/\" \"/abc\") ;; => \"/abc/\"
+  (str:ensure-suffix \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
-See also `str:ensure-start' and `str:ensure-wrapped-in'."
+See also `str:ensure-prefix' and `str:ensure-wrapped-in'."
   (cond
     ((null end)
      s)
@@ -540,7 +543,7 @@ Return a new string.
     (str:ensure-wrapped-in \"/\" \"/abc/\") ;; => \"/abc/\" (does nothing)
 
   See also: `str:enclosed-by-p'."
-  (str:ensure-start start/end (str:ensure-end start/end s)))
+  (str:ensure-prefix start/end (str:ensure-suffix start/end s)))
 
 (defun ensure (s &key wrapped-in prefix suffix)
   "The ensure functions return a string that has the specified prefix or suffix, appened if necessary.
@@ -579,8 +582,8 @@ If true, return S. Otherwise, return nil.
 
 Example:
 
-    (str:enclosed-by-p \"/\" \"/foo/\"  ;; => \"/foo/\"
-    (str:enclosed-by-p \"/\" \"/foo\"  ;; => nil
+    (str:wrapped-in-p \"/\" \"/foo/\"  ;; => \"/foo/\"
+    (str:wrapped-in-p \"/\" \"/foo\"  ;; => nil
 
 See also: UIOP:STRING-ENCLOSED-P (prefix s suffix).
 "

--- a/str.lisp
+++ b/str.lisp
@@ -68,6 +68,9 @@
   #:suffixp
   #:add-prefix
   #:add-suffix
+  #:ensure-end
+  #:ensure-wrapped-in
+  #:wrapped-in-p
   #:pad
   #:pad-left
   #:pad-right
@@ -84,6 +87,7 @@
   #:s-assoc-value
   #:count-substring
 
+  ;; case-related functions:
   #:downcase
   #:upcase
   #:capitalize

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -219,10 +219,12 @@
 2
 " (unlines '("1" "2" ""))))
 
-(subtest "starts-with?"
+(subtest "starts-with-p"
   (ok (starts-with? "foo" "foobar") "default case")
   (ok (starts-with? "" "foo") "with blank start")
   (ok (not (starts-with? "rs" "")) "with blank s")
+  (ok (not (starts-with? nil "")) "prefix is nil")
+  ;; (is (starts-with? "" nil) t) "s is nil: what do we want?")  ;; XXX: fix?
   (ok (not (starts-with? "foobar" "foo")) "with shorter s")
   (ok (starts-with? "" "") "with everything blank")
   (ok (not (starts-with? "FOO" "foobar")) "don't ignore case")
@@ -230,7 +232,7 @@
   (ok (starts-with? "FOO" "foobar" :ignore-case t) "ignore case")
   (ok (let ((*ignore-case* t)) (starts-with? "FOO" "foobar")) "ignore case"))
 
-(subtest "ends-with?"
+(subtest "ends-with-p"
   (ok (ends-with? "bar" "foobar") "default case")
   (ok (ends-with-p "bar" "foobar") "ends-with-p alias")
   (ok (not (ends-with? "BAR" "foobar")) "don't ignore case")
@@ -280,12 +282,14 @@
   (is (add-suffix '() "foo") '() "with void list"))
 
 (subtest "ensure-starts-with"
-  (is (ensure-starts-with "/" "/abc") "/abc" "default case")
-  (is (ensure-starts-with "/" "abc") "/abc" "default case 2")
-  (is (ensure-starts-with "/" "") "/" "default case void string")
+  (is (ensure-starts-with "/" "/abc") "/abc" "default case: existing prefix.")
+  (is (ensure-starts-with "/" "abc") "/abc" "default case: add prefix.")
+  (is (ensure-starts-with "/" "") "/" "blank string: add prefix")
   (is (ensure-starts-with #\/ "") "/" "with a char")
-  (is (ensure-starts-with "" "") "" "void strings")
-  (is (ensure-starts-with nil "") nil "nil")
+  (is (ensure-starts-with "" "") "" "blank strings")
+  (is (ensure-starts-with nil "") "" "prefix is nil, we want s")
+  (is (ensure-starts-with nil nil) nil "prefix and s are nil")
+  (is (ensure-starts-with "/" nil) nil "s is nil")
   (is (ensure-starts-with "/" "///abc") "///abc" "lots of slashes, but that's ok"))
 
 (subtest "ensure-ends-with"
@@ -294,7 +298,7 @@
   (is (ensure-ends-with "/" "") "/" "default case void string")
   (is (ensure-ends-with #\/ "") "/" "with a char")
   (is (ensure-ends-with "" "") "" "void strings")
-  (is (ensure-ends-with nil "") nil "nil")
+  (is (ensure-ends-with nil "foo") "foo" "prefix is nil, we want s")
   (is (ensure-ends-with "/" "abc///") "abc///" "lots of slashes, but that's ok"))
 
 (subtest "ensure-enclosed-by"
@@ -302,8 +306,11 @@
   (is (ensure-enclosed-by "/" "abc") "/abc/" "default case 2")
   (is (ensure-enclosed-by "/" "") "/" "default case void string")
   (is (ensure-enclosed-by #\/ "") "/" "with a char")
-  (is (ensure-enclosed-by "" "") "" "void strings")
-  (is (ensure-enclosed-by nil "") nil "nil")
+  (is (ensure-enclosed-by "" "") "" "blank strings")
+  (is (ensure-enclosed-by nil "") "" "prefix is nil, we want s")
+  ;; The following line is different that the original behaviour of starts-with-p:
+  (is (ensure-enclosed-by "" nil) nil "blank prefix, s is nil")
+  ;; (starts-with-p "" nil) ;; => T but below, we expect NIL.
   (is (ensure-enclosed-by nil nil) nil "nils")
   (is (ensure-enclosed-by "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
 

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -284,25 +284,25 @@
   (is (add-suffix '("foo" nil) "bar") '("foobar" "bar") "with a nil")
   (is (add-suffix '() "foo") '() "with void list"))
 
-(subtest "ensure-start"
-  (is (ensure-start "/" "/abc") "/abc" "default case: existing prefix.")
-  (is (ensure-start "/" "abc") "/abc" "default case: add prefix.")
-  (is (ensure-start "/" "") "/" "blank string: add prefix")
-  (is (ensure-start #\/ "") "/" "with a char")
-  (is (ensure-start "" "") "" "blank strings")
-  (is (ensure-start nil "") "" "prefix is nil, we want s")
-  (is (ensure-start nil nil) nil "prefix and s are nil")
-  (is (ensure-start "/" nil) nil "s is nil")
-  (is (ensure-start "/" "///abc") "///abc" "lots of slashes, but that's ok"))
+(subtest "ensure-prefix"
+  (is (ensure-prefix "/" "/abc") "/abc" "default case: existing prefix.")
+  (is (ensure-prefix "/" "abc") "/abc" "default case: add prefix.")
+  (is (ensure-prefix "/" "") "/" "blank string: add prefix")
+  (is (ensure-prefix #\/ "") "/" "with a char")
+  (is (ensure-prefix "" "") "" "blank strings")
+  (is (ensure-prefix nil "") "" "prefix is nil, we want s")
+  (is (ensure-prefix nil nil) nil "prefix and s are nil")
+  (is (ensure-prefix "/" nil) nil "s is nil")
+  (is (ensure-prefix "/" "///abc") "///abc" "lots of slashes, but that's ok"))
 
-(subtest "ensure-end"
-  (is (ensure-end "/" "/abc/") "/abc/" "default case")
-  (is (ensure-end "/" "abc") "abc/" "default case 2")
-  (is (ensure-end "/" "") "/" "default case void string")
-  (is (ensure-end #\/ "") "/" "with a char")
-  (is (ensure-end "" "") "" "void strings")
-  (is (ensure-end nil "foo") "foo" "prefix is nil, we want s")
-  (is (ensure-end "/" "abc///") "abc///" "lots of slashes, but that's ok"))
+(subtest "ensure-suffix"
+  (is (ensure-suffix "/" "/abc/") "/abc/" "default case")
+  (is (ensure-suffix "/" "abc") "abc/" "default case 2")
+  (is (ensure-suffix "/" "") "/" "default case void string")
+  (is (ensure-suffix #\/ "") "/" "with a char")
+  (is (ensure-suffix "" "") "" "void strings")
+  (is (ensure-suffix nil "foo") "foo" "prefix is nil, we want s")
+  (is (ensure-suffix "/" "abc///") "abc///" "lots of slashes, but that's ok"))
 
 (subtest "ensure-wrapped-in"
   (is (ensure-wrapped-in "/" "/abc/") "/abc/" "default case")
@@ -317,16 +317,21 @@
   (is (ensure-wrapped-in nil nil) nil "nils")
   (is (ensure-wrapped-in "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
 
-(subtest "enclosed-by-p"
-  (is (enclosed-by-p "/" "/foo/") "/foo/" "default case")
-  (is (enclosed-by-p "/" "/foo") nil "false case")
-  (is (enclosed-by-p "" "/foo/") "/foo/" "blank start/end")
-  (is (enclosed-by-p nil "/foo/") "/foo/" "blank start/end")
-  (is (enclosed-by-p nil nil) nil "nils")
-  (is (enclosed-by-p nil "") "" "nil and blank")
-  (is (enclosed-by-p "" nil) nil "blank and nil")
-  (is (enclosed-by-p #\/ "/foo") nil "with a char")
-  (is (enclosed-by-p "<3" "<3lisp<3") "<3lisp<3" "with a longer prefix."))
+(subtest "wrapped-in-p"
+  (is (wrapped-in-p "/" "/foo/") "/foo/" "default case")
+  (is (wrapped-in-p "/" "/foo") nil "false case")
+  (is (wrapped-in-p "" "/foo/") "/foo/" "blank start/end")
+  (is (wrapped-in-p nil "/foo/") "/foo/" "blank start/end")
+  (is (wrapped-in-p nil nil) nil "nils")
+  (is (wrapped-in-p nil "") "" "nil and blank")
+  (is (wrapped-in-p "" nil) nil "blank and nil")
+  (is (wrapped-in-p #\/ "/foo") nil "with a char")
+  (is (wrapped-in-p "<3" "<3lisp<3") "<3lisp<3" "with a longer prefix."))
+
+(subtest "ensure"
+  (is (ensure "foo" :prefix "-" :suffix "+") "-foo+" "ensure with prefix and suffix")
+  (is (ensure "foo") "foo" "ensure with no params")
+  (is (ensure "foo" :prefix nil :suffix nil :wrapped-in nil) "foo" "ensure with params to nil"))
 
 (subtest "pad left, right, center"
   (is (pad 10 "foo") "foo       "

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -314,6 +314,17 @@
   (is (ensure-enclosed-by nil nil) nil "nils")
   (is (ensure-enclosed-by "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
 
+(subtest "enclosed-by-p"
+  (is (enclosed-by-p "/" "/foo/") "/foo/" "default case")
+  (is (enclosed-by-p "/" "/foo") nil "false case")
+  (is (enclosed-by-p "" "/foo/") "/foo/" "blank start/end")
+  (is (enclosed-by-p nil "/foo/") "/foo/" "blank start/end")
+  (is (enclosed-by-p nil nil) nil "nils")
+  (is (enclosed-by-p nil "") "" "nil and blank")
+  (is (enclosed-by-p "" nil) nil "blank and nil")
+  (is (enclosed-by-p #\/ "/foo") nil "with a char")
+  (is (enclosed-by-p "<3" "<3lisp<3") "<3lisp<3" "with a longer prefix."))
+
 (subtest "pad left, right, center"
   (is (pad 10 "foo") "foo       "
       "pad adds spaces on the right by default.")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -279,6 +279,34 @@
   (is (add-suffix '("foo" nil) "bar") '("foobar" "bar") "with a nil")
   (is (add-suffix '() "foo") '() "with void list"))
 
+(subtest "ensure-starts-with"
+  (is (ensure-starts-with "/" "/abc") "/abc" "default case")
+  (is (ensure-starts-with "/" "abc") "/abc" "default case 2")
+  (is (ensure-starts-with "/" "") "/" "default case void string")
+  (is (ensure-starts-with #\/ "") "/" "with a char")
+  (is (ensure-starts-with "" "") "" "void strings")
+  (is (ensure-starts-with nil "") nil "nil")
+  (is (ensure-starts-with "/" "///abc") "///abc" "lots of slashes, but that's ok"))
+
+(subtest "ensure-ends-with"
+  (is (ensure-ends-with "/" "/abc/") "/abc/" "default case")
+  (is (ensure-ends-with "/" "abc") "abc/" "default case 2")
+  (is (ensure-ends-with "/" "") "/" "default case void string")
+  (is (ensure-ends-with #\/ "") "/" "with a char")
+  (is (ensure-ends-with "" "") "" "void strings")
+  (is (ensure-ends-with nil "") nil "nil")
+  (is (ensure-ends-with "/" "abc///") "abc///" "lots of slashes, but that's ok"))
+
+(subtest "ensure-enclosed-by"
+  (is (ensure-enclosed-by "/" "/abc/") "/abc/" "default case")
+  (is (ensure-enclosed-by "/" "abc") "/abc/" "default case 2")
+  (is (ensure-enclosed-by "/" "") "/" "default case void string")
+  (is (ensure-enclosed-by #\/ "") "/" "with a char")
+  (is (ensure-enclosed-by "" "") "" "void strings")
+  (is (ensure-enclosed-by nil "") nil "nil")
+  (is (ensure-enclosed-by nil nil) nil "nils")
+  (is (ensure-enclosed-by "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
+
 (subtest "pad left, right, center"
   (is (pad 10 "foo") "foo       "
       "pad adds spaces on the right by default.")

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -281,38 +281,38 @@
   (is (add-suffix '("foo" nil) "bar") '("foobar" "bar") "with a nil")
   (is (add-suffix '() "foo") '() "with void list"))
 
-(subtest "ensure-starts-with"
-  (is (ensure-starts-with "/" "/abc") "/abc" "default case: existing prefix.")
-  (is (ensure-starts-with "/" "abc") "/abc" "default case: add prefix.")
-  (is (ensure-starts-with "/" "") "/" "blank string: add prefix")
-  (is (ensure-starts-with #\/ "") "/" "with a char")
-  (is (ensure-starts-with "" "") "" "blank strings")
-  (is (ensure-starts-with nil "") "" "prefix is nil, we want s")
-  (is (ensure-starts-with nil nil) nil "prefix and s are nil")
-  (is (ensure-starts-with "/" nil) nil "s is nil")
-  (is (ensure-starts-with "/" "///abc") "///abc" "lots of slashes, but that's ok"))
+(subtest "ensure-start"
+  (is (ensure-start "/" "/abc") "/abc" "default case: existing prefix.")
+  (is (ensure-start "/" "abc") "/abc" "default case: add prefix.")
+  (is (ensure-start "/" "") "/" "blank string: add prefix")
+  (is (ensure-start #\/ "") "/" "with a char")
+  (is (ensure-start "" "") "" "blank strings")
+  (is (ensure-start nil "") "" "prefix is nil, we want s")
+  (is (ensure-start nil nil) nil "prefix and s are nil")
+  (is (ensure-start "/" nil) nil "s is nil")
+  (is (ensure-start "/" "///abc") "///abc" "lots of slashes, but that's ok"))
 
-(subtest "ensure-ends-with"
-  (is (ensure-ends-with "/" "/abc/") "/abc/" "default case")
-  (is (ensure-ends-with "/" "abc") "abc/" "default case 2")
-  (is (ensure-ends-with "/" "") "/" "default case void string")
-  (is (ensure-ends-with #\/ "") "/" "with a char")
-  (is (ensure-ends-with "" "") "" "void strings")
-  (is (ensure-ends-with nil "foo") "foo" "prefix is nil, we want s")
-  (is (ensure-ends-with "/" "abc///") "abc///" "lots of slashes, but that's ok"))
+(subtest "ensure-end"
+  (is (ensure-end "/" "/abc/") "/abc/" "default case")
+  (is (ensure-end "/" "abc") "abc/" "default case 2")
+  (is (ensure-end "/" "") "/" "default case void string")
+  (is (ensure-end #\/ "") "/" "with a char")
+  (is (ensure-end "" "") "" "void strings")
+  (is (ensure-end nil "foo") "foo" "prefix is nil, we want s")
+  (is (ensure-end "/" "abc///") "abc///" "lots of slashes, but that's ok"))
 
-(subtest "ensure-enclosed-by"
-  (is (ensure-enclosed-by "/" "/abc/") "/abc/" "default case")
-  (is (ensure-enclosed-by "/" "abc") "/abc/" "default case 2")
-  (is (ensure-enclosed-by "/" "") "/" "default case void string")
-  (is (ensure-enclosed-by #\/ "") "/" "with a char")
-  (is (ensure-enclosed-by "" "") "" "blank strings")
-  (is (ensure-enclosed-by nil "") "" "prefix is nil, we want s")
+(subtest "ensure-wrapped-in"
+  (is (ensure-wrapped-in "/" "/abc/") "/abc/" "default case")
+  (is (ensure-wrapped-in "/" "abc") "/abc/" "default case 2")
+  (is (ensure-wrapped-in "/" "") "/" "default case void string")
+  (is (ensure-wrapped-in #\/ "") "/" "with a char")
+  (is (ensure-wrapped-in "" "") "" "blank strings")
+  (is (ensure-wrapped-in nil "") "" "prefix is nil, we want s")
   ;; The following line is different that the original behaviour of starts-with-p:
-  (is (ensure-enclosed-by "" nil) nil "blank prefix, s is nil")
+  (is (ensure-wrapped-in "" nil) nil "blank prefix, s is nil")
   ;; (starts-with-p "" nil) ;; => T but below, we expect NIL.
-  (is (ensure-enclosed-by nil nil) nil "nils")
-  (is (ensure-enclosed-by "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
+  (is (ensure-wrapped-in nil nil) nil "nils")
+  (is (ensure-wrapped-in "/" "abc///") "/abc///" "lots of slashes, but that's ok"))
 
 (subtest "enclosed-by-p"
   (is (enclosed-by-p "/" "/foo/") "/foo/" "default case")


### PR DESCRIPTION
Example:

      (is (ensure-starts-with "/" "/abc") "/abc")


Feedback welcome (especially for naming).