### PR TITLE
Feat: keyword param char-bag for trim functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,15 @@ is equivalent to
 
 ### Tweak whitespace
 
-#### trim `(s)`
-Remove whitespaces at the beginning and end of `s`.
+#### trim `(s &key (char-bag *whitespaces*))`
+Removes all characters in `char-bag` (default: whitespaces) at the beginning and end of `s`.
+If supplied, `char-bag` has to be a sequence (e.g. string or list of characters).
 
 ```lisp
 (trim "  rst  ") ;; => "rst"
+(trim "abrstcd" :char-bag "ad") ;; => "brstc"
+(trim "efrstg" :char-bag (list #\e #\g)) => "frst"
+(trim "cdefgh" :char-bag (concat "c" "d" "h")) => "efg"
 ```
 
 Also `trim-left` and `trim-right`.

--- a/str.lisp
+++ b/str.lisp
@@ -146,23 +146,29 @@
 (defun version ()
   (print +version+))
 
-(defun trim-left (s)
-  "Remove whitespaces at the beginning of s."
-  (when s
-    (string-left-trim *whitespaces* s)))
+(defun trim-left (s &key (char-bag *whitespaces*))
+  "Removes all characters in `char-bag` (default: whitespaces) at the end of `s`.
+   If supplied, char-bag has to be a sequence (e.g. string or list of characters).
 
-(defun trim-right (s)
-  "Remove whitespaces at the end of s."
+   Example: (trim-left \"abrstcd\" :char-bag (list #\a #\d) ;; => \"abrstc\""
   (when s
-    (string-right-trim *whitespaces* s)))
+    (string-left-trim char-bag s)))
 
-(defun trim (s)
-  "Remove whitespaces at the beginning and end of s.
-@begin[lang=lisp](code)
-(trim \"  foo \") ;; => \"foo\"
-@end(code)"
+(defun trim-right (s &key (char-bag *whitespaces*))
+  "Removes all characters in `char-bag` (default: whitespaces) at the end of `s`.
+   If supplied, char-bag has to be a sequence (e.g. string or list of characters).
+
+   Example: (trim-right \"abrstcd\" :char-bag \"ad\")) ;; => \"abrstc\""
   (when s
-    (string-trim *whitespaces* s)))
+    (string-right-trim char-bag s)))
+
+(defun trim (s &key (char-bag *whitespaces*))
+  "Removes all characters in `char-bag` (default: whitespaces) at the beginning and end of `s`.
+   If supplied, char-bag has to be a sequence (e.g. string or list of characters).
+
+   Example: (trim \"abrstcd\" :char-bag (concat \"a\" \"d\")) ;; => \"brstc\""
+  (when s
+    (string-trim char-bag s)))
 
 (defun collapse-whitespaces (s)
   "Ensure there is only one space character between words.

--- a/str.lisp
+++ b/str.lisp
@@ -147,10 +147,11 @@
   (print +version+))
 
 (defun trim-left (s &key (char-bag *whitespaces*))
-  "Removes all characters in `char-bag` (default: whitespaces) at the end of `s`.
+  "Removes all characters in `char-bag` (default: whitespaces) at the beginning of `s`.
    If supplied, char-bag has to be a sequence (e.g. string or list of characters).
 
-   Example: (trim-left \"abrstcd\" :char-bag (list #\a #\d) ;; => \"abrstc\""
+   Examples: (trim-left \"  foo \") => \"foo \"
+             (trim-left \"abrstcd\" :char-bag (list #\a #\d) ;; => \"abrstc\""
   (when s
     (string-left-trim char-bag s)))
 
@@ -158,7 +159,8 @@
   "Removes all characters in `char-bag` (default: whitespaces) at the end of `s`.
    If supplied, char-bag has to be a sequence (e.g. string or list of characters).
 
-   Example: (trim-right \"abrstcd\" :char-bag \"ad\")) ;; => \"abrstc\""
+   Examples: (trim-right \"  foo \") => \"  foo\"
+             (trim-right \"abrstcd\" :char-bag \"ad\")) ;; => \"abrstc\""
   (when s
     (string-right-trim char-bag s)))
 
@@ -166,7 +168,8 @@
   "Removes all characters in `char-bag` (default: whitespaces) at the beginning and end of `s`.
    If supplied, char-bag has to be a sequence (e.g. string or list of characters).
 
-   Example: (trim \"abrstcd\" :char-bag (concat \"a\" \"d\")) ;; => \"brstc\""
+   Examples: (trim \"  foo \") => \"foo\"
+             (trim \"abrstcd\" :char-bag (concat \"a\" \"d\")) => \"brstc\""
   (when s
     (string-trim char-bag s)))
 

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -15,7 +15,10 @@
   (is "rst" (trim "  rst  "))
   (is nil (trim-left nil))
   (is nil (trim-right nil))
-  (is nil (trim nil)))
+  (is nil (trim nil))
+  (is "rst " (trim-left "abrst " :char-bag "ab"))
+  (is " rst" (trim-right " rstbc" :char-bag (list #\b #\c)))
+  (is "rst" (trim "drste" :char-bag "de")))
 
 (subtest "Collapse whitespaces"
   (is "foo bar baz" (collapse-whitespaces "foo  bar


### PR DESCRIPTION
- add keyword parameter `char-bag` to `trim`, `trim-right`, `trim-left`
- char-bag can be a sequence (e.g. list or string)
- char-bag defaults to `*whitespaces*`

- update tests for trim functions
- update documentation with examples

Is the parameter name `char-bag` appropriate? And do you like the documentation (same in docstring and readme)?