### PR TITLE
Feat: add *whitespaces* characters, export symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Why ?
 
 * modernity, simplicity and discoverability:
 
-  - `(str:trim s)` instead of `  (string-trim '(#\Space #\Newline #\Backspace #\Tab #\Linefeed #\Page #\Return #\Rubout) s))`,
+  - `(str:trim s)` instead of `(string-trim '(#\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page #\Return #\Space #\Rubout #\Next-Line #\No-break_space) s))`,
 or `str:concat strings` instead of an unusual `format` construct; one discoverable library instead of many;
 
 * consistence and composability, where `s` is always the last argument, which makes it

--- a/str.lisp
+++ b/str.lisp
@@ -124,6 +124,7 @@
   #:*ellipsis*
   #:*pad-char*
   #:*pad-side*
+  #:*whitespaces*
   #:version
   #:+version+
   #:?))

--- a/str.lisp
+++ b/str.lisp
@@ -139,7 +139,8 @@
   "The side of the string to add padding characters to. Can be one of :right, :left and :center.")
 
 (defvar *whitespaces* '(#\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page
-                        #\Return #\Space #\Rubout #\Next-Line #\No-break_space))
+                        #\Return #\Space #\Rubout #\Next-Line #\No-break_space)
+  "On some implementations, linefeed and newline represent the same character (code).")
 
 (defvar +version+ (asdf:component-version (asdf:find-system "str")))
 

--- a/str.lisp
+++ b/str.lisp
@@ -138,8 +138,8 @@
 (defparameter *pad-side* :right
   "The side of the string to add padding characters to. Can be one of :right, :left and :center.")
 
-(defvar *whitespaces* '(#\Space #\Newline #\Backspace #\Tab
-                        #\Linefeed #\Page #\Return #\Rubout))
+(defvar *whitespaces* '(#\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page
+                        #\Return #\Space #\Rubout #\Next-Line #\No-break_space))
 
 (defvar +version+ (asdf:component-version (asdf:find-system "str")))
 


### PR DESCRIPTION
- added: `#\Vt` `#\Next-Line` `#\No-break_space`
- also: order characters depending on their char-code

Two further questions might be:
1. Are there any more whitespace characters?
2. The char-code of `#\Linefeed` `#\Newline` (10) is identical and `#\Linefeed` even evaluates to `#\Newline`. So can `#\Linefeed` be discarded from the list?