### PR TITLE
Fix: Next-line char on unsuppported impls

### DIFF
--- a/str.lisp
+++ b/str.lisp
@@ -139,8 +139,10 @@
 (defparameter *pad-side* :right
   "The side of the string to add padding characters to. Can be one of :right, :left and :center.")
 
-(defvar *whitespaces* '(#\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page
-                        #\Return #\Space #\Rubout #\Next-Line #\No-break_space)
+(defvar *whitespaces* (list #\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page
+                            #\Return #\Space #\Rubout
+                            #+sbcl #\Next-Line #-sbcl (code-char 133)
+                            #\No-break_space)
   "On some implementations, linefeed and newline represent the same character (code).")
 
 (defvar +version+ (asdf:component-version (asdf:find-system "str")))


### PR DESCRIPTION
- `next-line` character is only supported on SBCL
- other implementations: `(code-char 133)`

This fixes issues introduced from #87 :  On other implementations than SBCL `#\next-line` char is not supported and therefore breaks them during compilation.
Unfortunately this is now included in the recent Quicklisp release ...