### PR TITLE
Fix: casing functions inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,8 @@ See also: `UIOP:STRING-ENCLOSED-P (prefix s suffix)`.
 We use
 [cl-change-case](https://github.com/rudolfochrist/cl-change-case/) (go
 thank him and star the repo!).
+We adapt these functions to also accept symbols and characters (like the inbuilt casing functions).
+Also the functions return `nil` when argument is `nil`.
 
 The available functions are:
 

--- a/str.lisp
+++ b/str.lisp
@@ -782,21 +782,39 @@ with `string-equal' (case-insensitive).
 (defun downcase (s)
   "Return the lowercase version of `s'.
   Calls the built-in `string-downcase', but returns nil if `s' is
-  nil (instead of the string \"nil\")."
+  nil (instead of the string \"nil\").
+
+  Examples:
+  (downcase \"Foo fooF\") => \"foo foof\"
+  (downcase :foo{foo.f) => \"foo{foo.f\"
+  (downcase #\F) => \"f\"
+  (downcase nil) => nil"
   (when s
     (string-downcase s)))
 
 (defun upcase (s)
   "Return the uppercase version of `s'.
   Call the built-in `string-upcase', but return nil if `s' is
-  nil (instead of the string \"NIL\")."
+  nil (instead of the string \"NIL\").
+
+  Examples:
+  (upcase \"Foo fooF\") => \"FOO FOOF\"
+  (upcase :foo{foo.f) => \"FOO{FOO.F\"
+  (upcase #\f) => \"F\"
+  (upcase nil) => nil"
   (when s
     (string-upcase s)))
 
 (defun capitalize (s)
   "Return the capitalized version of `s'.
   Calls the built-in `string-capitalize', but returns nil if `s' is
-  nil (instead of the string \"Nil\")."
+  nil (instead of the string \"Nil\").
+
+  Examples:
+  (capitalize \"Foo fooF\") => \"Foo fooF\"
+  (capitalize :foo{foo.f) => \"Foo{Foo.F\"
+  (capitalize #\f) => \"F\"
+  (capitalize nil)  => nil"
   (when s
     (string-capitalize s)))
 
@@ -804,86 +822,135 @@ with `string-equal' (case-insensitive).
 ;; and return nil when the argument is nil.
 
 (defun no-case (s &key (replacement " "))
-  "Return the no-cased version of `s'.
-  Calls `cl-change-case:no-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to lower case space delimited. Use REPLACEMENT as delimiter.
+
+  Examples:
+  (no-case \"Foo fooF\" :replacement \",\") => \"foo,foo,f\"
+  (no-case 'foo{foo.f) => \"foo foo f\"
+  (no-case #\F) => \"f\"
+  (no-case nil) => nil"
   (when s
     (cl-change-case:no-case (string s) :replacement replacement)))
 
 (defun camel-case (s &key merge-numbers)
-  "Return the camel-cased version of `s'.
-  Calls `cl-change-case:camel-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to camelCase.
+Dot-separated numbers like 1.2.3 will be replaced by underscores 1_2_3
+unless MERGE-NUMBERS is non-nil.
+
+  Examples:
+  (camel-case \"Foo fooF\") => \"fooFooF\"
+  (camel-case (quote foo{foo.f)) => \"fooFooF\"
+  (camel-case #\F) => \"f\"
+  (camel-case nil) => nil"
   (when s
     (cl-change-case:camel-case (string s) :merge-numbers merge-numbers)))
 
 (defun dot-case (s)
-  "Return the dot-cased version of `s'.
-  Calls `cl-change-case:dot-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to dot.case.
+
+  Examples:
+  (dot-case \"Foo fooF\") => \"foo.foo.f\"
+  (dot-case :foo{foo-f) => \"foo.foo.f\"
+  (dot-case #\F) => \"f\"
+  (dot-case nil) => nil"
   (when s
     (cl-change-case:dot-case (string s))))
 
 (defun header-case (s)
-  "Return the header-cased version of `s'.
-  Calls `cl-change-case:header-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to Header-Case.
+
+  Examples:
+  (header-case \"Foo fooF\") => \"Foo-Foo-F\"
+  (header-case 'foo{foo.f) => \"Foo-Foo-F\"
+  (header-case #\f) => \"F\"
+  (header-case nil) => nil"
   (when s
     (cl-change-case:header-case (string s))))
 
 (defun param-case (s)
-  "Return the param-cased version of `s'.
-  Calls `cl-change-case:param-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to param-case.
+
+  Examples:
+  (param-case \"Foo fooF\") => \"foo-foo-f\"
+  (param-case (quote foo{foo.f)) => \"foo-foo-f\"
+  (param-case #\F) => \"f\"
+  (param-case nil) => nil"
   (when s
     (cl-change-case:param-case (string s))))
 
 (defun pascal-case (s)
-  "Return the pascal-cased version of `s'.
-  Calls `cl-change-case:pascal-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to Pascal Case
+
+  Examples:
+  (pascal-case \"Foo fooF\") => \"FooFooF\"
+  (pascal-case :foo{foo.f) => \"FooFooF\"
+  (pascal-case #\f) => \"F\"
+  (pascal-case nil) => nil"
   (when s
     (cl-change-case:pascal-case (string s))))
 
 (defun path-case (s)
-  "Return the path-cased version of `s'.
-  Calls `cl-change-case:path-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to path/case
+
+  Examples:
+  (path-case \"Foo fooF\") => \"foo/foo/f\"
+  (path-case :foo{foo.f) => \"foo/foo/f\"
+  (path-case #\F) => \"f\"
+  (path-case nil) => nil"
   (when s
     (cl-change-case:path-case (string s))))
 
 (defun sentence-case (s)
-  "Return the sentence-cased version of `s'.
-  Calls `cl-change-case:sentence-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to Sentence case
+
+  Examples:
+  (sentence-case \"Foo.fooF\") => \"Foo foo f\"
+  (sentence-case (quote foo{foo.f)) => \"Foo foo f\"
+  (sentence-case #\f) => \"F\"
+  (sentence-case nil) => nil"
   (when s
     (cl-change-case:sentence-case (string s))))
 
 (defun snake-case (s)
-  "Return the snake-cased version of `s'.
-  Calls `cl-change-case:snake-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to snake_case
+
+  Examples:
+  (snake-case \"Foo fooF\") => \"foo_foo_f\"
+  (snake-case 'foo{foo.f) => \"foo_foo_f\"
+  (snake-case #\f) => \"f\"
+  (snake-case nil) => nil"
   (when s
     (cl-change-case:snake-case (string s))))
 
 (defun swap-case (s)
-  "Return the swap-cased version of `s'.
-  Calls `cl-change-case:swap-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Reverse case for each character in `s'.
+
+  Examples:
+  (swap-case \"Foo fooF\") => \"fOO FOOf\"
+  (swap-case :FOO{FOO.F) => \"foo{foo.f\"
+  (swap-case #\f) => \"F\"
+  (swap-case nil) => nil"
   (when s
     (cl-change-case:swap-case (string s))))
 
 (defun title-case (s)
-  "Return the title-cased version of `s'.
-  Calls `cl-change-case:title-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to Title Case
+
+  Examples:
+  (title-case \"Foo fooF\") => \"Foo Foo F\"
+  (title-case :foo{foo.f) => \"Foo Foo F\"
+  (title-case #\f) => \"F\"
+  (title-case nil) => nil"
   (when s
     (cl-change-case:title-case (string s))))
 
 (defun constant-case (s)
-  "Return the constant-cased version of `s'.
-  Calls `cl-change-case:constant-case' after coercing `s' into a string,
-  but returns nil if `s' is nil."
+  "Transform `s' to CONSTANT_CASE.
+
+  (constant-case \"Foo fooF\") => \"FOO_FOO_F\"
+  (constant-case :foo{foo.f) => \"FOO_FOO_F\"
+  (constant-case #\f) => \"F\"
+  (constant-case nil) => nil"
   (when s
     (cl-change-case:constant-case (string s))))
 

--- a/str.lisp
+++ b/str.lisp
@@ -2,37 +2,7 @@
 
 (defpackage str
   (:use :cl)
-  (:import-from :cl-change-case
-                #:no-case
-                #:camel-case
-                #:dot-case
-                #:header-case
-                #:param-case
-                #:pascal-case
-                #:path-case
-                #:sentence-case
-                #:snake-case
-                #:swap-case
-                #:title-case
-                #:constant-case)
   (:export
-   ;; cl-change-case functions:
-   ;; (we don't re-export all of them. Otherwise, use UIOP:define-package's :reexport)
-   ;; (for example, we define downcasep instead of re-exporting string-lower-case-p)
-  #:no-case
-  #:camel-case
-  #:dot-case
-  #:header-case
-  #:param-case
-  #:pascal-case
-  #:path-case
-  #:sentence-case
-  #:snake-case
-  #:swap-case
-  #:title-case
-  #:constant-case
-
-   ;; ours:
   #:remove-punctuation
   #:containsp
   #:s-member
@@ -95,6 +65,20 @@
   #:downcase
   #:upcase
   #:capitalize
+  #:no-case
+  #:camel-case
+  #:dot-case
+  #:header-case
+  #:param-case
+  #:pascal-case
+  #:path-case
+  #:sentence-case
+  #:snake-case
+  #:swap-case
+  #:title-case
+  #:constant-case
+
+  ;; predicate functions
   #:downcasep
   #:upcasep
   #:has-alphanum-p
@@ -793,7 +777,7 @@ with `string-equal' (case-insensitive).
 
 ;;; Case
 
-;; Small wrappers around built-ins, but they fix surprises.
+;; Small wrappers around built-ins that return nil when the argument is nil.
 
 (defun downcase (s)
   "Return the lowercase version of `s'.
@@ -815,6 +799,93 @@ with `string-equal' (case-insensitive).
   nil (instead of the string \"Nil\")."
   (when s
     (string-capitalize s)))
+
+;; Wrappers around cl-change-case functions that coerce the argument into a string
+;; and return nil when the argument is nil.
+
+(defun no-case (s &key (replacement " "))
+  "Return the no-cased version of `s'.
+  Calls `cl-change-case:no-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:no-case (string s) :replacement replacement)))
+
+(defun camel-case (s &key merge-numbers)
+  "Return the camel-cased version of `s'.
+  Calls `cl-change-case:camel-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:camel-case (string s) :merge-numbers merge-numbers)))
+
+(defun dot-case (s)
+  "Return the dot-cased version of `s'.
+  Calls `cl-change-case:dot-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:dot-case (string s))))
+
+(defun header-case (s)
+  "Return the header-cased version of `s'.
+  Calls `cl-change-case:header-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:header-case (string s))))
+
+(defun param-case (s)
+  "Return the param-cased version of `s'.
+  Calls `cl-change-case:param-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:param-case (string s))))
+
+(defun pascal-case (s)
+  "Return the pascal-cased version of `s'.
+  Calls `cl-change-case:pascal-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:pascal-case (string s))))
+
+(defun path-case (s)
+  "Return the path-cased version of `s'.
+  Calls `cl-change-case:path-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:path-case (string s))))
+
+(defun sentence-case (s)
+  "Return the sentence-cased version of `s'.
+  Calls `cl-change-case:sentence-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:sentence-case (string s))))
+
+(defun snake-case (s)
+  "Return the snake-cased version of `s'.
+  Calls `cl-change-case:snake-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:snake-case (string s))))
+
+(defun swap-case (s)
+  "Return the swap-cased version of `s'.
+  Calls `cl-change-case:swap-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:swap-case (string s))))
+
+(defun title-case (s)
+  "Return the title-cased version of `s'.
+  Calls `cl-change-case:title-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:title-case (string s))))
+
+(defun constant-case (s)
+  "Return the constant-cased version of `s'.
+  Calls `cl-change-case:constant-case' after coercing `s' into a string,
+  but returns nil if `s' is nil."
+  (when s
+    (cl-change-case:constant-case (string s))))
 
 ;;; Case predicates.
 

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -450,7 +450,67 @@
   (is (upcase "foo") "FOO")
   (is (capitalize nil) nil
       "capitalize nil returns nil, not a string.")
-  (is (capitalize "foo") "Foo"))
+  (is (capitalize "foo") "Foo")
+  (is (no-case nil) nil
+      "No-case returns nil, not a string.")
+  (is (no-case "Foo") "foo")
+  (is (no-case :foo) "foo"
+      "Works also on symbols.")
+  (is (camel-case nil) nil
+      "Camel-case returns nil, not a string.")
+  (is (camel-case "Foo Foo") "fooFoo")
+  (is (camel-case :foo.foo) "fooFoo"
+      "Works also on symbols.")
+  (is (dot-case nil) nil
+      "Dot-case returns nil, not a string.")
+  (is (dot-case "Foo Foo") "foo.foo")
+  (is (dot-case :foo-foo) "foo.foo"
+      "Works also on symbols.")
+  (is (header-case nil) nil
+      "Header-case returns nil, not a string.")
+  (is (header-case "Foo Foo") "Foo-Foo")
+  (is (header-case :foo-foo) "Foo-Foo"
+      "Works also on symbols.")
+  (is (param-case nil) nil
+      "Param-case returns nil, not a string.")
+  (is (param-case "Foo Foo") "foo-foo")
+  (is (param-case :foo.foo) "foo-foo"
+      "Works also on symbols.")
+  (is (pascal-case nil) nil
+      "pascal-case returns nil, not a string.")
+  (is (pascal-case "Foo Foo") "FooFoo")
+  (is (pascal-case :foo.foo) "FooFoo"
+      "Works also on symbols.")
+  (is (path-case nil) nil
+      "Path-case returns nil, not a string.")
+  (is (path-case "Foo Foo") "foo/foo")
+  (is (path-case :foo.foo) "foo/foo"
+      "Works also on symbols.")
+  (is (sentence-case nil) nil
+      "sentence-case returns nil, not a string.")
+  (is (sentence-case "Foo Foo") "Foo foo")
+  (is (sentence-case :foo.foo) "Foo foo"
+      "Works also on symbols.")
+  (is (snake-case nil) nil
+      "snake-case returns nil, not a string.")
+  (is (snake-case "Foo Foo") "foo_foo")
+  (is (snake-case :foo.foo) "foo_foo"
+      "Works also on symbols.")
+  (is (swap-case nil) nil
+      "swap-case returns nil, not a string.")
+  (is (swap-case "Foo Foo") "fOO fOO")
+  (is (swap-case :FOO.FOO) "foo.foo"
+      "Works also on symbols.")
+  (is (title-case nil) nil
+      "swap-case returns nil, not a string.")
+  (is (title-case "FoO foo") "Fo O Foo")
+  (is (title-case :foo.foo) "Foo Foo"
+      "Works also on symbols.")
+  (is (constant-case nil) nil
+      "constant-case returns nil, not a string.")
+  (is (constant-case "Foo Foo") "FOO_FOO")
+  (is (constant-case :foo.foo) "FOO_FOO"
+      "Works also on symbols."))
 
 (subtest "case predicates"
   (is (downcasep nil) nil "downcasep nil")


### PR DESCRIPTION
Closes #91 
The `no-case` could also be implemented like this:
```
  (defun no-case (s &key (replacement nil replacement-p))
  "Return the no-cased version of `s'.
  Calls `cl-change-case:no-case' after coercing `s' into a string,
  but returns nil if `s' is nil."
  (when s
    (if replacement-p
        (cl-change-case:no-case (string s) :replacement replacement)
        (cl-change-case:no-case (string s)))
```
One idea that appeared was to add the documentation of cl-change-case to our casing functions with `#`. Something like this:
```
  (defun dot-case (s)
  #.(concat (documentation 'cl-change-case:dot-case 'function)
  "Return the dot-cased version of `s'.
  Calls `cl-change-case:dot-case' after coercing `s' into a string,
  but returns nil if `s' is nil.")
  (when s
    (cl-change-case:dot-case (string s))))
```
Then the REPL documentation would be more helpful for str:dot-case etc. On the other hand it might reduce readability of the code.