### PR TITLE
Fix: reimplement replace-using

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The only dependency is `cl-ppcre`.
         - [Others](#others)
             - [replace-first `(old new s)`](#replace-first-old-new-s)
             - [replace-all `(old new s)`](#replace-all-old-new-s)
-            - [replace-using `(plist s)`](#replace-using-plist-s)
+            - [replace-using `(replacement-list s)`](#replace-using-replacement-list-s)
             - [remove-punctuation (s &key replacement)](#remove-punctuation-s-key-replacement)
             - [prefix `(list-of-strings)` (renamed in 0.9)](#prefix-list-of-strings-renamed-in-09)
             - [suffix `(list-of-strings)`](#suffix-list-of-strings)
@@ -770,11 +770,11 @@ If the replacement is only one character, you can use `substitute`:
     ;; "foo+bar+baz"
 
 
-#### replace-using `(plist s)`
+#### replace-using `(replacement-list s)`
 
-Replace all associations given by pairs in a plist and return a new string.
+Replace all associations given by pairs in a replacement-list and return a new string.
 
-The plist is a list alternating a string to replace (case sensitive) and its replacement.
+The replacement-list is a list alternating a string to replace (case sensitive) and its replacement.
 
 Example:
 

--- a/str.lisp
+++ b/str.lisp
@@ -343,10 +343,10 @@ It uses `subseq' with differences:
   ;; foo\'bar
   )
 
-(defun replace-using (plist s)
-  "Replace all associations given by pairs in a plist and return a new string.
+(defun replace-using (replacement-list s)
+  "Replace all associations given by pairs in a list and return a new string.
 
-  The plist is a list alternating a string to replace (case sensitive) and its replacement.
+  The replacement-list alternates a string to replace (case sensitive) and its replacement.
 
   Example:
   (replace-using (list \"{{phone}}\" \"987\")
@@ -355,10 +355,11 @@ It uses `subseq' with differences:
   \"call 987\"
 
   It calls `replace-all' as many times as there are replacements to do."
-  (check-type plist list)
-  (dotimes (i (- (length plist)
-                 1))
-    (setf s (str:replace-all (nth i plist) (nth (incf i) plist) s)))
+  (loop for remaining-list on replacement-list by #'cddr do
+    (let ((key (first remaining-list))
+          (value (second remaining-list)))
+      (declare (string key value))
+      (setf s (replace-all key value s))))
   s)
 
 (defun emptyp (s)

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -7,6 +7,7 @@
                 #:in-suite
                 #:test
                 #:is
+                #:signals
                 #:def-fixture
                 #:with-fixture)
   (:export #:str
@@ -54,8 +55,11 @@
 (test replace-using
   (is (string= "foo" (replace-using (list "a" "o") "faa")))
   (is (string= "fooAA" (replace-using (list "a" "o") "faaAA")))
-  (is (string= "faa" (replace-using (list "a") "faa")))
-  (is (string= "fooAA" (replace-using (list "a" "o" "A") "faaAA")))
+  (is (string= "fooBB" (replace-using (list "a" "o" "A" "B") "faaAA")))
+  (signals error (replace-using (list "a") "faa"))
+  (signals error (replace-using (list "a" "o" "A") "faaAA"))
+  (signals error (replace-using (list 1 "C") "faaAA"))
+  (signals error (replace-using (list "f" 'test) "faaAA"))
   (is (string= "faa" (replace-using nil "faa"))))
 
 (def-suite lengthen-functions


### PR DESCRIPTION
- Reimplement `replace-using` with `loop`
- update and add more test-cases for `replace-using`
- update docstring and README

tested on `sbcl`, `ccl`, `allegro`, `abcl`

closes #100 

@Yehouda @vindarel 