### PR TITLE
Fix: lispworks no-break-space

### DIFF
--- a/str.lisp
+++ b/str.lisp
@@ -134,7 +134,7 @@
 (defvar *whitespaces* (list #\Backspace #\Tab #\Linefeed #\Newline #\Vt #\Page
                             #\Return #\Space #\Rubout
                             #+sbcl #\Next-Line #-sbcl (code-char 133)
-                            #\No-break_space)
+                            #+lispworks #\no-break-space #-lispworks #\No-break_space)
   "On some implementations, linefeed and newline represent the same character (code).")
 
 (defvar +version+ (asdf:component-version (asdf:find-system "str")))


### PR DESCRIPTION
Other implementations use #\No-break_space while Lispworks uses #\no-break-space. 

I have no Lispworks implementation set up, so can you @ijitai or anyone with access to Lispworks confirm this works now?

Closes #99 