### PR TITLE
Add regex to split function family

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,22 +492,28 @@ A terminal newline character does *not* result in an extra empty string
 
 Join the list of strings with a newline character.
 
-#### split `(separator s &key omit-nulls limit start end)`
+#### split `(separator s &key omit-nulls limit start end regex)`
 
-Split into subtrings (unlike cl-ppcre, without a regexp). If
+Split into subtrings. If
 `omit-nulls` is non-nil, zero-length substrings are omitted.
+
+By default, metacharacters are treated as normal characters.
+ If `regex` is not `nil`, then `separator` is treated as regular expression.
 
 ```lisp
 (split "+" "foo++bar") ;; => ("foo" "" "bar")
 (split #\+ "foo++bar") ;; => ("foo" "" "bar")
 (split "+" "foo++bar" :omit-nulls t) ;; => ("foo" "bar")
+
+(split "[,|;]" "foo,bar;baz") ;; => ("foo,bar;baz")
+(split "[,|;]" "foo,bar;baz" :regex t) ;; => ("foo" "bar" "baz")
 ```
 
 cl-ppcre has an inconsistency such that when the separator appears at
 the end, it doesn't return a trailing empty string. But we do **since
 v0.14** (october, 2019).
 
-#### rsplit `(separator s &key limit)`
+#### rsplit `(separator s &key limit regex)`
 
 Similar to `split`, but split from the end. In particular, this will
 be different from `split` when a `:limit` is provided, but in more
@@ -527,7 +533,7 @@ ways to split the string.
 ~~~
 
 
-#### split-omit-nulls
+#### split-omit-nulls `(separator s &key regex)`
 
 Because it is a common pattern and it can be clearer than an option
 coming after many parenthesis.

--- a/str.lisp
+++ b/str.lisp
@@ -225,10 +225,10 @@
 (defun split (separator s &key (omit-nulls *omit-nulls*) limit (start 0) end regex)
   "Split s into substring by separator (cl-ppcre takes a regex, we do not).
 
-  `limit' limits the number of elements returned (i.e. the string is
-  split at most `limit' - 1 times).
+   `limit' limits the number of elements returned (i.e. the string is
+   split at most `limit' - 1 times).
 
-  If `regex` keyword is not `nil`, separator is treated as regular expression"
+   If `regex` keyword is not `nil`, separator is treated as regular expression"
   ;; cl-ppcre:split doesn't return a null string if the separator appears at the end of s.
   (let* ((limit (or limit (1+ (length s))))
          (res (if regex
@@ -240,7 +240,9 @@
 
 (defun rsplit (sep s &key (omit-nulls *omit-nulls*) limit regex)
   "Similar to `split`, except we split from the end. In particular,
-the results will be be different when `limit` is provided."
+the results will be be different when `limit` is provided.
+
+   If `regex` keyword is not `nil`, separator is treated as regular expression"
   (nreverse
    (mapcar 'nreverse
            (split (if regex
@@ -255,7 +257,8 @@ the results will be be different when `limit` is provided."
   "Call split with :omit-nulls to t.
 
    Can be clearer in certain situations.
-  "
+
+   If `regex` keyword is not `nil`, separator is treated as regular expression"
   (split separator s :omit-nulls t :regex regex))
 
 (defun substring (start end s)

--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -360,7 +360,9 @@
     (is (equalp '("foo" "   ") (split "+" "foo+++   ++++"))
         "omit-nulls and blanks"))
   (is (equalp '("foo" "bar") (split "," "foo,bar")))
-  (is (equalp '("foo" "ABbar") (split "ABAB" "fooABABABbar"))))
+  (is (equalp '("foo" "ABbar") (split "ABAB" "fooABABABbar")))
+  (is (equalp '("foo" "bar" "baz") (split "[,|;]" "foo,bar;baz" :regex t)))
+  (is (equalp '("foo" "bar" "" "" "baz") (split "[,|;+]" "foo,bar;;;baz" :regex t))))
 
 (test rsplit
   (is (equalp '("foo" "bar") (rsplit " " "foo bar")))
@@ -371,7 +373,8 @@
   (is (equalp '("" "var" "log" "mail.log") (rsplit "/" "/var/log/mail.log" :limit 4)))
   (is (equalp '("foo" "bar") (rsplit "LONG" "fooLONGbar")))
   (is (equalp '("foo" "bar" "") (rsplit "LONG" "fooLONGbarLONG" :limit 3)))
-  (is (equalp '("fooAB" "bar") (rsplit "ABAB" "fooABABABbar"))))
+  (is (equalp '("fooAB" "bar") (rsplit "ABAB" "fooABABABbar")))
+  (is (equalp '("foo" "bar" "" "" "baz") (rsplit "[,|;+]" "foo,bar;;;baz" :regex t))))
 
 (test lines
   (is (string= nil (lines nil)))


### PR DESCRIPTION
Add regex keyword to `split` `rsplit` and `split-omit-nulls`. Update README and tests

Relates:
[Issue](https://github.com/vindarel/cl-str/issues/63#issuecomment-1497851615)
[PR](https://github.com/vindarel/cl-str/pull/106)