### PR TITLE
(minor) Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The only dependency is `cl-ppcre`.
             - [s-assoc-value `(alist key)`](#s-assoc-value-alist-key)
     - [Macros](#macros)
         - [string-case](#string-case)
-        - [match (experimental) · new in Feb, 2024](#match-experimental-·-new-in-feb-2024)
+        - [match (experimental) · new in Feb, 2024](#match-experimental--new-in-feb-2024)
     - [Changelog](#changelog)
     - [Dev and test](#dev-and-test)
         - [Main test suite](#main-test-suite)


### PR DESCRIPTION
Just fix the readme link. 

FYI, I have a tool for this purpose if someone interested in. [catalog-of-markdown](https://crates.io/crates/catalog-of-markdown)