### PR TITLE
match: add type annotation to enable optimization level 3

### DIFF
--- a/str.lisp
+++ b/str.lisp
@@ -762,14 +762,15 @@ Returns the string written to file."
                                     (cl-ppcre:scan-to-strings
                                      ,(apply #'str:concat (reverse regex))
                                      ,str)
-                                  (declare (ignore ,whole-str))
+                                  (declare (ignore ,whole-str)
+                                           ((or null (simple-array string (*))) ,regs))
                                   (when ,regs
                                     (let ,(loop for (v ind) in vars
                                                 unless (string= (symbol-name v) "_")
                                                   collect v)
                                       ,@(loop for (v ind) in vars
                                               unless (string= (symbol-name v) "_")
-                                                collect `(setf ,v (elt ,regs ,ind)))
+                                                collect `(setf ,v (aref ,regs ,ind)))
                                       (return-from ,block
                                         (progn ,@forms)))))))))))
 


### PR DESCRIPTION
I added a type annotation to the `match` macro so that the compiler won't complain when the optimization level is 3.

Example:

```lisp
(ql:quickload "str")

(declaim (optimize (speed 3)))

(defun aa ()
  (str:match ""
    ((a "a") a)))
```

In the current code, the compiler (sbcl) will print notes:

```
; in: DEFUN AA
;     (STR:MATCH ""
;       ((A "a") A))
; --> MULTIPLE-VALUE-BIND MULTIPLE-VALUE-CALL FUNCTION WHEN IF LET SETF
; --> SETQ THE
; ==>
;   (ELT #:G2 0)
; 
; note: unable to
;   optimize
; due to type uncertainty:
;   The first argument is a (OR CONS VECTOR
;                               SB-KERNEL:EXTENDED-SEQUENCE), not a (SIMPLE-ARRAY
;                                                                    * (*)).
; 
; note: unable to
;   optimize
; due to type uncertainty:
;   The first argument is a (OR CONS VECTOR
;                               SB-KERNEL:EXTENDED-SEQUENCE), not a LIST.
; 
; compilation unit finished
;   printed 2 notes
```

After this PR, `sbcl` will be happy with it.