### PR TITLE
Optimize str:repeat for large workloads

### DIFF
--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -687,7 +687,9 @@ def"))
 
 (test repeat
   (is (string= "" (repeat 10 "")))
-  (is (string= "foofoofoo" (repeat 3 "foo"))))
+  (is (string= "" (repeat 10 nil)))
+  (is (string= "foofoofoo" (repeat 3 "foo")))
+  (is (= (length (repeat 100000 "c")) 100000)))
 
 (test fit
   (is (string= "hello" (fit 5 "hello"))


### PR DESCRIPTION
When the workload is sufficiently large, `str:repeat` allocates all chunks of the expected output onto the stack to call `concat`, causing an overflow.

This commit retains the current behavior for workloads with <=10,000 characters in the expected output, but for larger workloads it chunks the work to minimize the chance of overflowing the stack or heap, while retaining decent performance.

Also using a bunch of type declarations to minimize the impact of this change on performance.

Verified no stack or heap overflows when repeating 10 characters 1,000,000 times or 1 character 10,000,000 times, on SBCL with default runtime settings. 

`(time (dotimes (i 1000) (length (str:repeat 50000 "s"))))` runs significantly faster with the new code, a ~1.46 second improvement from ~1.94s to ~0.48s. This performance improvement even on smaller values of `count` is likely due to the `string` type declaration in `simple-repeat`, using `loop` instead of `dotimes`/`cons`/`setf` to collect strings, and possibly due to moving less data in/out of the stack at a time.
`(time (length (str:repeat 10000000 "s")))` takes ~11.56s to run and (unlike the old version) doesn't blow up the heap or stack.