### PR TITLE
Improve correctness and function declarations

### DIFF
--- a/test/test-str.lisp
+++ b/test/test-str.lisp
@@ -279,7 +279,8 @@
   (is (string= "foo~bar" (join "~" '("foo" "bar"))))
   (is (string= "foo~~~bar" (join "~" '("foo~" "~bar"))))
   (is (string= "foo,bar" (join #\, '("foo" "bar"))))
-  (is (string= "" (join nil nil))))
+  (is (string= "" (join nil nil)))
+  (is (string= "abcde" (join nil '("a" "b" "c" "d" "e")))))
 
 (test unwords
   (is (string= "" (unwords nil)))
@@ -461,6 +462,7 @@ def"))
   (is (containsp "foo" "blafoobar") "default")
   (is (not (containsp "foo" "")) "with no string")
   (is (not (containsp "" nil)) "a blank substring in a nil str")
+  (is (not (containsp nil "")) "a nil substring in a blank str")
   (is (not (containsp "foo" nil)) "with string nil")
   (is (not (containsp "Foo" "blafoobar")) "with case")
   (is (containsp "Foo" "blafoobar" :ignore-case t) "ignore case")
@@ -485,7 +487,14 @@ def"))
 
 (test lettersp
   (is (lettersp "éß") "letters with accents and ß")
-  (is (not (lettersp " e é,")) "no letters"))
+  (is (not (lettersp " e é,")) "no letters")
+  (is (not (lettersp "éß
+")) "not lettersp with newline"))
+
+(test lettersnump
+  (is (lettersnump "éß3") "lettersnump letters with accents and ß and a number")
+  (is (not (lettersnump "éß3
+")) "not lettersnump with newline"))
 
 (test has-letters-p 
   (is (has-letters-p " e é ß") "has-letters-p default")
@@ -581,14 +590,17 @@ def"))
   (is (not (alphanump " rst123ldv ")) "alphanump no space")
   (is (not (alphanump "rst,123+ldv")) "alphanump no punctuation")
   (is (not (alphanump ",+")) "alphanump no punctuation")
-  (is (not (alphanump "abcéß")) "alphanump no accents"))
+  (is (not (alphanump "abcéß
+")) "not alphanump with newline"))
 
 (test alphap
   (is (alphap "abcDEf") "alphap default")
   (is (not (alphap "abc,de")) "alphap no punctuation")
   (is (not (alphap "abcdeé")) "alphap no accents")
   (is (not (alphap "abc de")) "alphap no space")
-  (is (not (alphap " ")) "alphap blank"))
+  (is (not (alphap " ")) "alphap blank")
+  (is (not (alphap "abc
+")) "not alphap with newline"))
 
 (test digitp
   (is (not (digitp "abc")) "digitp letters")


### PR DESCRIPTION
Correctness changes:
- `join` now treats a `nil` separator as the empty string, rather than the string `"nil"`, conforming to the semantics in the README of not converting `nil` to `"nil"`.
- `containsp` now automatically returns `nil` if either string input is `nil`.
- `alphanump` and similar now use the correct regex checks for multi-line strings, rather than accepting an input if it has any line matching their specification.

Optimization changes:
- Multiple non-recursive functions have been inlined
- Multiple functions have `ftype` declarations
- In local testing, there is a ~0.1s reduction from ~1.05s to ~0.95s in `(time (dotimes (i 100) (with-output-to-string (throwaway) (let ((*standard-output* throwaway)) (asdf:test-system :str)))))`, despite the new tests in this version.
  - Note: Most of the tests use `constantp` inputs, so performance improvements here derive mainly from the inlining; they do not represent benefits from the `ftype` declarations in user-code.
  - Note: The comparison was specifically with the contents of https://github.com/vindarel/cl-str/pull/128, but that still shows an improvement over the original.